### PR TITLE
Fix reduction func in ensembles example #3

### DIFF
--- a/docs/src/features/ensemble.md
+++ b/docs/src/features/ensemble.md
@@ -451,7 +451,8 @@ as sufficiently small:
 ```julia
 function reduction(u,batch,I)
   u = append!(u,batch)
-  u,((var(u)/sqrt(last(I)))/mean(u)<0.5) ? true : false
+  finished = (var(u) / sqrt(last(I))) / mean(u) < 0.5
+  u, finished
 end
 ```
 


### PR DESCRIPTION
Fixed a redundant `$condition ? true : false` ternary statement and used the extra space to add spaces around binary operators.