### PR TITLE
Broken example in Implicit Extrapolation Methods and typo fix

### DIFF
--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -380,7 +380,7 @@ So the above implementation of `f` becomes valid.
 
 The following are adaptive order, adaptive step size extrapolation methods:
 
-- `AitkenNevillie` - Euler extrapolation using Aitken-Neville with the Romberg Sequence.
+- `AitkenNeville` - Euler extrapolation using Aitken-Neville with the Romberg Sequence.
 - `ExtrapolationMidpointDeuflhard` - Midpoint extrapolation using Barycentric coordinates
 - `ExtrapolationMidpointHairerWanner` - Midpoint extrapolation using Barycentric coordinates,
   following Hairer's `ODEX` in the adaptivity behavior.
@@ -408,7 +408,7 @@ alg = ExtrapolationMidpointDeuflhard(max_order=7,min_order=4,init_order=4,sequen
 solve(prob,alg)
 ```
 
-Note that the order that is referred to is the extrapolation order. For `AitkenNevillie`
+Note that the order that is referred to is the extrapolation order. For `AitkenNeville`
 this is the order of the method, for the others an extrapolation order of `n`
 gives an order `2(n+1)` method.
 
@@ -592,7 +592,7 @@ methods have the additional argument:
 To override, utilize the keyword arguments. For example:
 
 ```julia
-alg = ImplicitEulerExtrapolation(max_order=7,min_order=4,init_order=4,sequence=:bulirsch)
+alg = ImplicitDeuflhardExtrapolation(max_order=7,min_order=4,init_order=4,sequence=:bulirsch)
 solve(prob,alg)
 ```
 


### PR DESCRIPTION
https://docs.sciml.ai/stable/solvers/ode_solve/#Parallelized-Implicit-Extrapolation-Methods-1

MWE:
```
julia> alg = ImplicitEulerExtrapolation(max_order=7,min_order=4,init_order=4,sequence=:bulirsch)
ERROR: MethodError: no method matching ImplicitEulerExtrapolation(; max_order=7, min_order=4, init_order=4, sequence=:bulirsch)
Closest candidates are:
  ImplicitEulerExtrapolation(; chunk_size, autodiff, diff_type, linsolve, max_order, min_order, init_order, threading) at C:\Users\Utkarsh\.julia\dev\OrdinaryDiffEq\src\algorithms.jl:63 got unsupported keyword argument "sequence"
Stacktrace:
 [1] kwerr(::NamedTuple{(:max_order, :min_order, :init_order, :sequence),Tuple{Int64,Int64,Int64,Symbol}}, ::Type{T} where T) at .\error.jl:157
 [2] top-level scope at REPL[64]:1
```
@ChrisRackauckas 