### PR TITLE
Add missing footnote and fix duplicated heading

### DIFF
--- a/docs/src/solvers/nonautonomous_linear_ode.md
+++ b/docs/src/solvers/nonautonomous_linear_ode.md
@@ -147,3 +147,5 @@ sol = solve(prob,MagnusAdapt4())
 These methods can be used when ``A`` is dependent on both time and state variables, i.e. ``A(u,t)``
 
 - `CG3` - Third order Crouch-Grossman method.
+
+[^1]: A description of IOP can be found in this [paper](https://doi.org/10.1016/j.jcp.2018.06.026).

--- a/docs/src/types/nonautonomous_linear_ode.md
+++ b/docs/src/types/nonautonomous_linear_ode.md
@@ -1,4 +1,4 @@
-# [Non-autonomous Linear ODE / Lie Group Problems](@id dynamical_prob)
+# [Non-autonomous Linear ODE / Lie Group Problems](@id nonauto_dynamical_prob)
 
 Non-autonomous linear ODEs show up in a lot of scientific problems where
 the differential equation lives on a manifold such as Lie Group. In these


### PR DESCRIPTION
This PR contains two minor fixes to the docs:
1. Add the missing footnote for the IOP reference in the `LinearExponential` integrator documentation.
2. Change the section label for the non-autonomous problems section to not be the same as the label for the ODE problems section. The non-autonomous section is actually never referenced, so no places need to be updated with the change (but the ODE section is referenced, so this caused confusion over which section to link to).

Fixes #424 