### PR TITLE
Added ProbNumDiffEq.jl to the full list of ODE solvers

### DIFF
--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -1328,9 +1328,7 @@ Plot recipes are provided which will plot the stability region for a given table
 
 ProbNumDiffEq.jl provides _probabilistic_ numerical solvers for ODEs.
 By casting the solution of ODEs as a problem of Bayesian inference, they return a posterior probability distribution over ODE solutions and thereby provide estimates of their own numerical approximation error.
-
-Both implemented solvers, `EK0` and `EK1`, have adaptive timestepping and their order can be specified by the user.
-Using `EK1` is recommended if the Jacobian of the vector field is available.
+The solvers have adaptive timestepping, their order can be freely specified, and the returned posterior distribution naturally enables dense output and sampling.
 The full documentation is available at [ProbNumDiffEq.jl](https://nathanaelbosch.github.io/ProbNumDiffEq.jl/stable/).
 
 Note that this setup is not automatically included with DifferentialEquations.jl.
@@ -1340,7 +1338,7 @@ To use the following algorithms, you must install and use ProbNumDiffEq.jl:
 using ProbNumDiffEq
 ```
 
+- `EK1(order=3)` - A semi-implicit ODE solver based on extended Kalman filtering and smoothing with first order linearization. Recommended, but requires that the Jacobian of the vector field is specified.
 - `EK0(order=3)` - An explicit ODE solver based on extended Kalman filtering and smoothing with zeroth order linearization.
-- `EK1(order=3)` - A semi-implicit ODE solver based on extended Kalman filtering and smoothing with first order linearization. Requires that the Jacobian of the vector field is specified.
 
 [^1]: Koskela, A. (2015). Approximating the matrix exponential of an advection-diffusion operator using the incomplete orthogonalization method. In Numerical Mathematics and Advanced Applications-ENUMATH 2013 (pp. 345-353). Springer, Cham.

--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -1324,4 +1324,22 @@ Tableau docstrings should have appropriate citations (if not, file an issue).
 
 Plot recipes are provided which will plot the stability region for a given tableau.
 
+### ProbNumDiffEq.jl
+
+ProbNumDiffEq.jl provides _probabilistic_ numerical solvers for ODEs.
+By casting the solution of ODEs as a problem of Bayesian inference, these so-called ODE filters return a posterior probability distribution over ODE solutions and thereby provide estimates of their own numerical approximation error.
+
+Note that this setup is not automatically included with DifferentialEquations.jl.
+To use the following algorithms, you must install and use ProbNumDiffEq.jl:
+```julia
+]add ProbNumDiffEq
+using ProbNumDiffEq
+```
+
+Both implemented solvers, `EK0` and `EK1`, have adaptive timestepping and their order can be specified by the user.
+Using `EK1` is recommended if the Jacobian of the vector field is available.
+The full documentation is available at [ProbNumDiffEq.jl](https://nathanaelbosch.github.io/ProbNumDiffEq.jl/stable/).
+- `EK0(order=3)` - An explicit ODE solver based on extended Kalman filtering and smoothing with zeroth order linearization.
+- `EK1(order=3)` - A semi-implicit ODE solver based on extended Kalman filtering and smoothing with first order linearization. Requires that the Jacobian of the vector field is specified.
+
 [^1]: Koskela, A. (2015). Approximating the matrix exponential of an advection-diffusion operator using the incomplete orthogonalization method. In Numerical Mathematics and Advanced Applications-ENUMATH 2013 (pp. 345-353). Springer, Cham.

--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -1327,7 +1327,11 @@ Plot recipes are provided which will plot the stability region for a given table
 ### ProbNumDiffEq.jl
 
 ProbNumDiffEq.jl provides _probabilistic_ numerical solvers for ODEs.
-By casting the solution of ODEs as a problem of Bayesian inference, these so-called ODE filters return a posterior probability distribution over ODE solutions and thereby provide estimates of their own numerical approximation error.
+By casting the solution of ODEs as a problem of Bayesian inference, they return a posterior probability distribution over ODE solutions and thereby provide estimates of their own numerical approximation error.
+
+Both implemented solvers, `EK0` and `EK1`, have adaptive timestepping and their order can be specified by the user.
+Using `EK1` is recommended if the Jacobian of the vector field is available.
+The full documentation is available at [ProbNumDiffEq.jl](https://nathanaelbosch.github.io/ProbNumDiffEq.jl/stable/).
 
 Note that this setup is not automatically included with DifferentialEquations.jl.
 To use the following algorithms, you must install and use ProbNumDiffEq.jl:
@@ -1336,9 +1340,6 @@ To use the following algorithms, you must install and use ProbNumDiffEq.jl:
 using ProbNumDiffEq
 ```
 
-Both implemented solvers, `EK0` and `EK1`, have adaptive timestepping and their order can be specified by the user.
-Using `EK1` is recommended if the Jacobian of the vector field is available.
-The full documentation is available at [ProbNumDiffEq.jl](https://nathanaelbosch.github.io/ProbNumDiffEq.jl/stable/).
 - `EK0(order=3)` - An explicit ODE solver based on extended Kalman filtering and smoothing with zeroth order linearization.
 - `EK1(order=3)` - A semi-implicit ODE solver based on extended Kalman filtering and smoothing with first order linearization. Requires that the Jacobian of the vector field is specified.
 


### PR DESCRIPTION
Hi, I just added [ProbNumDiffEq.jl](https://github.com/nathanaelbosch/ProbNumDiffEq.jl) to the full list of ODE solvers. This package provides probabilistic numerical ODE solvers, and was developed with compatibility to the DifferentialEquations.jl ecosystem in mind.

Please let me know about any changes I should make to this PR in order to add it to your documentation. And thank you for your feedback!