### PR TITLE
Explicitely mention that global_logger needs to be called first

### DIFF
--- a/docs/src/features/progress_bar.md
+++ b/docs/src/features/progress_bar.md
@@ -23,7 +23,7 @@ To use the progress bars outside of Juno, use [TerminalLoggers.jl](https://githu
 , if you want it enabled by default.
 
 Otherwise, follow the example down below. Note that `global_logger` is initialized 
-before other julia calls are done. This step is crucial, otherwise no logging will 
+before any other julia call. This step is crucial, otherwise no logging will 
 appear in the terminal.
 
 ```julia

--- a/docs/src/features/progress_bar.md
+++ b/docs/src/features/progress_bar.md
@@ -19,7 +19,12 @@ and find tough locations for the solvers.
 ## Using Progress Bars Outside Juno
 
 To use the progress bars outside of Juno, use [TerminalLoggers.jl](https://github.com/c42f/TerminalLoggers.jl).
-The following is an example for redirecting the logging to the terminal:
+[Follow these direction to add TerminalLogging to your startup.jl](https://c42f.github.io/TerminalLoggers.jl/stable/#Installation-and-setup-1)
+, if you want it enabled by default.
+
+Otherwise, follow the example down below. Note that `global_logger` is initialized 
+before other julia calls are done. This step is crucial, otherwise no logging will 
+appear in the terminal.
 
 ```julia
 using Logging: global_logger
@@ -38,4 +43,3 @@ solve(
 )
 ```
 
-To do this by default, [follow these direction to add TerminalLogging to your startup.jl](https://c42f.github.io/TerminalLoggers.jl/stable/#Installation-and-setup-1).

--- a/docs/src/features/progress_bar.md
+++ b/docs/src/features/progress_bar.md
@@ -19,7 +19,7 @@ and find tough locations for the solvers.
 ## Using Progress Bars Outside Juno
 
 To use the progress bars outside of Juno, use [TerminalLoggers.jl](https://github.com/c42f/TerminalLoggers.jl).
-[Follow these direction to add TerminalLogging to your startup.jl](https://c42f.github.io/TerminalLoggers.jl/stable/#Installation-and-setup-1)
+[Follow these directions to add TerminalLogging to your startup.jl](https://c42f.github.io/TerminalLoggers.jl/stable/#Installation-and-setup-1)
 , if you want it enabled by default.
 
 Otherwise, follow the example down below. Note that `global_logger` is initialized 
@@ -42,4 +42,3 @@ solve(
     progress_steps = 1,
 )
 ```
-


### PR DESCRIPTION
I hope these few changes can point out clearer that `global_logger` should be either called as the very first thing in the `.jl` file or set up in the `startup.jl`. Based on this conversation: https://julialang.zulipchat.com/#narrow/stream/274208-helpdesk-(published)/topic/Progress.20Bar.20in.20Terminal.20with.20DifferentialEquations.2Ejl