### PR TITLE
fix calling signature of g for ManifoldProjection

### DIFF
--- a/docs/src/features/callback_library.md
+++ b/docs/src/features/callback_library.md
@@ -28,11 +28,12 @@ ManifoldProjection(g; nlsolve=NLSOLVEJL_SETUP(), save=true, autonomous=numargs(g
 ```
 
 - `g`: The residual function for the manifold. This is an inplace function of form
-  `g(u, resid)` or `g(t, u, resid)` which writes to the residual the difference from
-  the manifold components.
+  `g(resid, u)` or `g(resid, u, p, t)` which writes to the residual `resid` the 
+  difference from the manifold components. Here, it is assumed that `resid` is of
+  the same shape as `u`.
 - `nlsolve`: A nonlinear solver as defined [in the nlsolve format](@ref linear_nonlinear).
 - `save`: Whether to do the save after the callback is applied. Standard saving is unchanged.
-- `autonomous`: Whether `g` is an autonomous function of the form `g(u, resid)`.
+- `autonomous`: Whether `g` is an autonomous function of the form `g(resid, u)`.
 - `nlopts`: Optional arguments to nonlinear solver which can be any of the [NLsolve keywords](https://github.com/JuliaNLSolvers/NLsolve.jl#fine-tunings).
 
 ### Example


### PR DESCRIPTION
The documentation seems to be outdated - the signature did not match the convention used in the source code.