### PR TITLE
Fix order of return values in integrator intervals() example

### DIFF
--- a/docs/src/basics/integrator.md
+++ b/docs/src/basics/integrator.md
@@ -59,7 +59,7 @@ end
 and the `intervals` iterator lets you view the full interval:
 
 ```julia
-for (tprev,uprev,u,t) in intervals(integrator)
+for (uprev,tprev,u,t) in intervals(integrator)
   @show tprev,t
 end
 ```


### PR DESCRIPTION
Small error on the order of the return values for `intervals(integrator)` example 

It should be: `uprev, tprev, u, t` ([integrator_interface.jl#L439](https://github.com/SciML/SciMLBase.jl/blob/ca50226c8db0f446fd28e70344f34a86c962aade/src/integrator_interface.jl#L439))

