### PR TITLE
fix order of parameters for DynamicalODEProblem and HamiltonianProblem

### DIFF
--- a/docs/src/solvers/dynamical_solve.md
+++ b/docs/src/solvers/dynamical_solve.md
@@ -6,9 +6,9 @@ that can be specialized on in the solver for more efficiency.
 These algorithms require an ODE defined in the following ways:
 
 ```julia
-DynamicalODEProblem{isinplace}(f1,f2,u0,v0,tspan,p=NullParameters();kwargs...)
+DynamicalODEProblem{isinplace}(f1,f2,v0,u0,tspan,p=NullParameters();kwargs...)
 SecondOrderODEProblem{isinplace}(f,du0,u0,tspan,p=NullParameters();kwargs...)
-HamiltonianProblem{T}(H,q0,p0,tspan,p=NullParameters();kwargs...)
+HamiltonianProblem{T}(H,p0,q0,tspan,p=NullParameters();kwargs...)
 ```
 
 These correspond to partitioned equations of motion:

--- a/docs/src/types/dynamical_types.md
+++ b/docs/src/types/dynamical_types.md
@@ -100,7 +100,7 @@ to define equations of motion from the corresponding Hamiltonian. To define a
 `HamiltonianProblem` one only needs to specify the Hamiltonian:
 
 ```math
-H(q,p)
+H(p,q)
 ```
 
 and autodifferentiation (via ForwardDiff.jl) will create the appropriate
@@ -109,13 +109,13 @@ equations.
 ### Constructors
 
 ```julia
-HamiltonianProblem{T}(H,p0,q0,tspan;kwargs...)
+HamiltonianProblem{T}(H,p0,q0,tspan,param=nothing;kwargs...)
 ```
 
 ### Fields
 
-* `H`: The Hamiltonian `H(q,p,params)` which returns a scalar.
+* `H`: The Hamiltonian `H(p,q,params)` which returns a scalar.
 * `p0`: The initial momentums.
 * `q0`: The initial positions.
 * `tspan`: The timespan for the problem.
-* `p`: Defaults to `nothing`. `p` will be passed to `H`'s `params`. 
+* `param`: Defaults to `nothing`. `param` will be passed to `H`'s `params`. 


### PR DESCRIPTION
Some parameters for DynamicalODEProblem and HamiltonianProblem were switched, so I reordered them to match the source code.

It should fix this [issue](https://github.com/SciML/DiffEqDocs.jl/issues/451)