### PR TITLE
document new low-storage schemes

### DIFF
--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -327,6 +327,12 @@ Royal Society, 2011.).
 - `CKLLSRK65_4M_4R` - 6-stage, fifth order low-storage scheme, optimised for compressible Navier–Stokes equations.
 - `CKLLSRK85_4FM_4R` - 8-stage, fifth order low-storage scheme, optimised for compressible Navier–Stokes equations.
 - `CKLLSRK75_4M_5R` - 7-stage, fifth order low-storage scheme, optimised for compressible Navier–Stokes equations.
+- `RDPK3Sp35` - 5-stage, third order low-storage scheme with embedded error estimator, optimized for compressible fluid mechanics.
+- `RDPK3SpFSAL35` - 5-stage, third order low-storage scheme with embedded error estimator, optimized for compressible fluid mechanics.
+- `RDPK3Sp49` - 9-stage, fourth order low-storage scheme with embedded error estimator, optimized for compressible fluid mechanics.
+- `RDPK3SpFSAL49` - 9-stage, fourth order low-storage scheme with embedded error estimator, optimized for compressible fluid mechanics.
+- `RDPK3Sp510` - 10-stage, fifth order low-storage scheme with embedded error estimator, optimized for compressible fluid mechanics.
+- `RDPK3SpFSAL510` - 10-stage, fifth order low-storage scheme with embedded error estimator, optimized for compressible fluid mechanics.
 
 __NOTE__: All the 2N Methods (`ORK256`, `CarpenterKennedy2N54`, `NDBLSRK124`, `NDBLSRK134`, `NDBLSRK144`, `DGLDDRK73_C`, `DGLDDRK84_C`, `DGLDDRK84_F` and `HSLDDRK64`) work on the basic principle of being able to perform step `S1 = S1 + F(S2)` in just 2 registers. Certain optimizations have been done to achieve this theoritical limit (when `alias_u0` is set) but have a limitation that `du` should always be on the left hand side (assignments only) in the implementation.
 


### PR DESCRIPTION
This documents the new low-storage schemes added in https://github.com/SciML/OrdinaryDiffEq.jl/pull/1384.