### PR TITLE
kwarg appears to be a syntax error for derivative of interplant

### DIFF
--- a/docs/src/basics/solution.md
+++ b/docs/src/basics/solution.md
@@ -90,7 +90,7 @@ sol(t)
 Note that the interpolating function allows for `t` to be a vector and uses this to speed up the interpolation calculations. The full API for the interpolations is
 
 ```julia
-sol(t,deriv=Val{0};idxs=nothing,continuity=:left)
+sol(t,Val{0};idxs=nothing,continuity=:left)
 ```
 
 The optional argument `deriv` lets you choose the number `n` derivative to solve the interpolation for, defaulting with `n=0`. Note that most of the derivatives have not yet been implemented (though it's not hard, it just has to be done by hand for each algorithm. Open an issue if there's a specific one you need). `continuity` describes whether to satisfy left or right continuity when a discontinuity is saved. The default is `:left`, i.e. grab the value before the callback's change, but can be changed to `:right`. `idxs` allows you to choose the indices the interpolation should solve for. For example,


### PR DESCRIPTION
When using the doc-recommended syntax for the derivative of the interpolation I obtain a syntax error:

```
julia> sol(0.0,deriv=Val{1})
ERROR: MethodError: no method matching (::ODESolution{Float64, 1, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Vector{Vector{Float64}}, ODEProblem{Float64, Tuple{Float64, Float64}, false, SciMLBase.NullParameters, ODEFunction{false, typeof(f), LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, Tsit5, OrdinaryDiffEq.InterpolationData{ODEFunction{false, typeof(f), LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Vector{Float64}, Vector{Float64}, Vector{Vector{Float64}}, OrdinaryDiffEq.Tsit5ConstantCache{Float64, Float64}}, DiffEqBase.DEStats})(::Float64, ::Type{Val{0}}; deriv=Val{1})
Use square brackets [] for indexing an Array.
Closest candidates are:
  (::ODESolution)(::Any, ::Any, ::Type; idxs, continuity) at /Users/nathompson7/.julia/packages/SciMLBase/cU5k7/src/solutions/ode_solutions.jl:19 got unsupported keyword argument "deriv"
  (::ODESolution)(::Real, ::Any, ::AbstractVector{<:Integer}, ::Any) at /Users/nathompson7/.julia/packages/SciMLBase/cU5k7/src/solutions/ode_solutions.jl:32 got unsupported keyword argument "deriv"
  (::ODESolution)(::Real, ::Any, ::AbstractVector, ::Any) at /Users/nathompson7/.julia/packages/SciMLBase/cU5k7/src/solutions/ode_solutions.jl:55 got unsupported keyword argument "deriv"
  ...
Stacktrace:
 [1] kwerr(::NamedTuple{(:deriv,), Tuple{DataType}}, ::ODESolution{Float64, 1, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Vector{Vector{Float64}}, ODEProblem{Float64, Tuple{Float64, Float64}, false, SciMLBase.NullParameters, ODEFunction{false, typeof(f), LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, Tsit5, OrdinaryDiffEq.InterpolationData{ODEFunction{false, typeof(f), LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Vector{Float64}, Vector{Float64}, Vector{Vector{Float64}}, OrdinaryDiffEq.Tsit5ConstantCache{Float64, Float64}}, DiffEqBase.DEStats}, ::Float64, ::Type)
   @ Base ./error.jl:163
 [2] top-level scope
   @ REPL[20]:1
```

Removing the `kwarg` fixes the issue:

```
julia> sol(0.0,Val{1})
0.505
```