### PR TITLE
TerminalLoggers site change c42f -> JuliaLogging

### DIFF
--- a/docs/src/features/progress_bar.md
+++ b/docs/src/features/progress_bar.md
@@ -18,9 +18,9 @@ and find tough locations for the solvers.
 
 ## Using Progress Bars Outside Juno
 
-To use the progress bars outside of Juno, use [TerminalLoggers.jl](https://github.com/c42f/TerminalLoggers.jl).
-[Follow these directions to add TerminalLogging to your startup.jl](https://c42f.github.io/TerminalLoggers.jl/stable/#Installation-and-setup-1)
-, if you want it enabled by default.
+To use the progress bars outside of Juno, use [TerminalLoggers.jl](https://github.com/JuliaLogging/TerminalLoggers.jl).
+[Follow these directions to add TerminalLogging to your startup.jl](https://julialogging.github.io/TerminalLoggers.jl/stable/#Installation-and-setup-1),
+if you want it enabled by default.
 
 Otherwise, follow the example down below. Note that `global_logger` is initialized 
 before any other julia call. This step is crucial, otherwise no logging will 


### PR DESCRIPTION
https://c42f.github.io/TerminalLoggers.jl/stable/#Installation-and-setup-1 is not a valid link anymore.