### PR TITLE
Another fix to the linsolve example

### DIFF
--- a/docs/src/features/linear_nonlinear.md
+++ b/docs/src/features/linear_nonlinear.md
@@ -133,7 +133,7 @@ function is created. For example, for an LU-Factorization, we would like to use
 using LinearAlgebra
 function linsolve!(::Type{Val{:init}},f,u0; kwargs...)
   function _linsolve!(x,A,b,update_matrix=false; kwargs...)
-    _A = lu!(A)
+    _A = lu(A)
     ldiv!(x,_A,b)
   end
 end


### PR DESCRIPTION
From discussion on slack, Rosenbrock integrators will reuse the `A` later, so it shouldn't be modified by the linear solver