### PR TITLE
Updated the overal description of callback types

### DIFF
--- a/docs/src/features/callback_functions.md
+++ b/docs/src/features/callback_functions.md
@@ -7,12 +7,10 @@ types can be used to build libraries of extension behavior.
 
 ## The Callback Types
 
-The callback types are defined as follows. There are three primitive callback types: the
-`ContinuousCallback`, `DiscreteCallback` and the `VectorContinuousCallback`. The [`ContinuousCallback`](@ref) is
-applied when a continuous condition function hits zero. This type of callback
-implements what is known in other problem solving environments as an Event. A
-[`DiscreteCallback`](@ref) is applied when its `condition` function is `true`. The [`VectorContinuousCallback`](@ref) works
-like a vector of `ContinuousCallbacks` and lets the user specify which callback is called when.
+The callback types are defined as follows. There are three primitive callback types: the `ContinuousCallback`, `DiscreteCallback` and the `VectorContinuousCallback`: 
+- The [`ContinuousCallback`](@ref) is applied when a given continuous *condition function* hits zero. This hitting can happen even within an integration step and the solver must be able to detect it and adjust the integration step accordingly. This type of callback implements what is known in other problem solving environments as an *Event*. 
+- The [`DiscreteCallback`](@ref) is applied when its *condition function* is `true`, but the condition is only evaluated at the end of every integration step. 
+- The [`VectorContinuousCallback`](@ref) works like a vector of `ContinuousCallbacks` and lets the user specify which callback is called when.
 
 ### ContinuousCallback
 


### PR DESCRIPTION
Highlighted that the difference between `ContinuousCallback` and `DiscreteCallback` is that the former checks hitting-the-zero even **within the integration step**, while the latter only checks if the condition is true **at the end of (every) integration step**.