### PR TITLE
Corrected prominent links to developer documentation in overview

### DIFF
--- a/docs/src/basics/overview.md
+++ b/docs/src/basics/overview.md
@@ -86,10 +86,10 @@ finalized results to large audiences. The tools for algorithm development allow 
 easy convergence testing, benchmarking, and higher order analysis (stability plotting,
 etc.). This is one of the reasons why DifferentialEquations.jl contains many algorithms
 which are unique and the results of recent publications! Please check out the
-[developer documentation](https://juliadiffeq.github.io/DiffEqDevDocs.jl/dev/)
+[developer documentation](https://devdocs.sciml.ai/dev/)
 for more information on using the development tools.
 
 Note that DifferentialEquations.jl allows for distributed development, meaning that
 algorithms which "plug-into ecosystem" don't have to be a part of the major packages.
-If you are interested in adding your work to the ecosystem, checkout the [developer documentation](https://juliadiffeq.github.io/DiffEqDevDocs.jl/dev/index.html)
+If you are interested in adding your work to the ecosystem, checkout the [developer documentation](https://devdocs.sciml.ai/dev/)
 for more information.


### PR DESCRIPTION
Pretty straightforward, fixed two links. I've identified others, but I'm leaving that for another day/issue. As background, this was referenced in #513 .