### PR TITLE
Fix ode type vanderpol_stiff

### DIFF
--- a/docs/src/types/ode_types.md
+++ b/docs/src/types/ode_types.md
@@ -72,7 +72,7 @@ prob_ode_fitzhughnagumo
 prob_ode_threebody
 prob_ode_pleiades
 prob_ode_vanderpol
-prob_ode_vanstiff
+prob_ode_vanderpol_stiff
 prob_ode_rober
 prob_ode_rigidbody
 prob_ode_hires


### PR DESCRIPTION
The ODE type ```prob_ode_vanstiff``` has changed to ```prob_ode_vanderpol_stiff```.

See:
https://github.com/SciML/DiffEqProblemLibrary.jl/blob/e1232b3ef6f29f5894d7164090ca54d4267a6e56/src/ode/ode_simple_nonlinear_prob.jl#L90