### PR TITLE
Add dt for RandomEM example usage in RODE Solvers

### DIFF
--- a/docs/src/solvers/rode_solve.md
+++ b/docs/src/solvers/rode_solve.md
@@ -16,5 +16,5 @@ Each of the StochasticDiffEq.jl solvers come with a linear interpolation.
 Example usage:
 
 ```julia
-sol = solve(prob,RandomEM())
+sol = solve(prob,RandomEM(),dt=1/100)
 ```


### PR DESCRIPTION
When we are using `RandomEM` solver, we need to specify `dt`