### PR TITLE
update callback description for sensealgs and add NILSAS

### DIFF
--- a/docs/src/analysis/sensitivity.md
+++ b/docs/src/analysis/sensitivity.md
@@ -206,9 +206,7 @@ the definition of the methods.
   sensitivity analysis for propagating derivatives by solving the extended ODE.
   Only supports ODEs.
 - `ForwardDiffSensitivity(;chunk_size=0,convert_tspan=true)`: An implementation
-  of discrete forward sensitivity analysis through ForwardDiff.jl. This algorithm
-  can differentiate code with callbacks when `convert_tspan=true`, but will be
-  faster when `convert_tspan=false`.
+  of discrete forward sensitivity analysis through ForwardDiff.jl.
 - `BacksolveAdjoint(;checkpointing=true,ADKwargs...)`: An implementation of
   adjoint sensitivity analysis using a backwards solution of the ODE. By default
   this algorithm will use the values from the forward pass to perturb the backwards
@@ -243,21 +241,24 @@ the definition of the methods.
   solver. Currently fails.
 - `SensitivityADPassThrough()`: Ignores all adjoint definitions and
   proceeds to do standard AD through the `solve` functions.
-- `ForwardLSS()`, `AdjointLSS()`, and `NILSS(nseg,nstep)`: Implementation of
-  shadowing methods for chaotic systems with a long-time averaged objective. See
-  the [sensitivity analysis for chaotic systems (shadowing methods) section](@ref shadowing_methods)
-  for more details.
+- `ForwardLSS()`, `AdjointLSS()`, `NILSS(nseg,nstep)`, `NILSAS(nseg,nstep,M)`:
+  Implementation of shadowing methods for chaotic systems with a long-time averaged
+  objective. See the [sensitivity analysis for chaotic systems (shadowing methods)
+  section](@ref shadowing_methods) for more details.
 
 The `ReverseDiffAdjoint()`, `TrackerAdjoint()`, `ZygoteAdjoint()`, and `SensitivityADPassThrough()` algorithms all offer differentiate-through-the-solver adjoints, each based on their respective automatic differentiation packages. If you're not sure which to use, `ReverseDiffAdjoint()` is generally a stable and performant best if using the CPU, while `TrackerAdjoint()` is required if you need GPUs. Note that `SensitivityADPassThrough()` is more or less an internal implementation detail. For example, `ReverseDiffAdjoint()` is implemented by invoking `ReverseDiff`'s AD functionality on `solve(...; sensealg=SensitivityADPassThrough())`.
 
-All methods based on discrete sensitivity analysis via automatic differentiation,
-like `ReverseDiffAdjoint`, `TrackerAdjoint`, or `ForwardDiffAdjoint` are fully
+`ForwardDiffSensitivity` can differentiate code with callbacks when `convert_tspan=true`,
+but will be faster when `convert_tspan=false`.
+All methods based on discrete adjoint sensitivity analysis via automatic differentiation,
+like `ReverseDiffAdjoint`, `TrackerAdjoint`, or `QuadratureAdjoint` are fully
 compatible with events. This applies to ODEs, SDEs, DAEs, and DDEs.
 The continuous adjoint sensitivities `BacksolveAdjoint`, `InterpolatingAdjoint`,
 and `QuadratureAdjoint` are compatible with events for ODEs. `BacksolveAdjoint` and
 `InterpolatingAdjoint` can also handle events for SDEs. Use `BacksolveAdjoint` if
 the event terminates the time evolution and several states are saved. Currently,
 the continuous adjoint sensitivities do not support multiple events per time point.
+The shadowing methods are not compatible with callbacks.
 
 ### Internal Automatic Differentiation Options (ADKwargs)
 
@@ -728,7 +729,7 @@ Thus one should check the stability of the backsolve on their type of problem be
 enabling this method. Additionally, using checkpointing with backsolve can be a
 low memory way to stabilize it.
 
-## Sensitivity analysis for chaotic systems (shadowing methods)
+## [Sensitivity analysis for chaotic systems (shadowing methods)](@id shadowing_methods)
 
 Let us define the instantaneous objective ``g(u,p)`` which depends on the state `u`
 and the parameter `p` of the differential equation. Then, if the objective is a


### PR DESCRIPTION
It's a bit redundant regarding 
https://diffeqflux.sciml.ai/dev/examples/hybrid_diffeq/ 
https://diffeqflux.sciml.ai/dev/examples/bouncing_ball/

However, only mentioning the compatibility explicitly for the sensealgs that do not work, doesn't seem to work out nicely because we probably want to keep the statement:

> This algorithm can differentiate code with callbacks when `convert_tspan=true`, but will be
>  faster when `convert_tspan=false`.

for `ForwardDiffSensitivity`.