### PR TITLE
Rerun starts from one in EnsembleProblem

### DIFF
--- a/docs/src/features/ensemble.md
+++ b/docs/src/features/ensemble.md
@@ -20,15 +20,15 @@ EnsembleProblem(prob::DEProblem;
                 u_init = [], safetycopy = prob_func !== DEFAULT_PROB_FUNC)
 ```
 
-* `prob_func`: The function by which the problem is to be modified. `prob`
-  is the problem, `i` is the unique id `1:trajectories` for the problem, and
-  `repeat` is for if the iteration of the repeat. At first it's `0`, but if
-  `rerun` was true this will be `1`, `2`, etc. counting the number of times
-  problem `i` has been repeated.
 * `output_func`: The function determines what is saved from the solution to the
   output array. Defaults to saving the solution itself. The output is
   `(out,rerun)` where `out` is the output and `rerun` is a boolean which
-  designates whether to rerun
+  designates whether to rerun.
+* `prob_func`: The function by which the problem is to be modified. `prob`
+  is the problem, `i` is the unique id `1:trajectories` for the problem, and
+  `repeat` is the iteration of the repeat. At first it is `1`, but if
+  `rerun` was true this will be `2`, `3`, etc. counting the number of times
+  problem `i` has been repeated.
 * `reduction`: This function determines how to reduce the data in each batch.
   Defaults to appending the data from the batches. The second part of the output
   determines whether the simulation has converged. If `true`, the simulation


### PR DESCRIPTION
I also changed the order of `output_func` and `prob_func` for consistency with `EnsembleProblem`.