### PR TITLE
EnsembleProblem safetycopy clarification

### DIFF
--- a/docs/src/features/ensemble.md
+++ b/docs/src/features/ensemble.md
@@ -38,7 +38,9 @@ EnsembleProblem(prob::DEProblem;
   as without this, modifying the arguments of something in the `prob_func`, such
   as parameters or caches stored within the user function, are not necessarily
   thread-safe. If you know that your function is thread-safe, then setting this
-  to `false` can improve performance when used with threads.
+  to `false` can improve performance when used with threads. For nested problems,
+  e.g., SDE problems with custom noise processes, `deepcopy` might be
+  insufficient. In such cases use a custom `prob_func`.
 
 One can specify a function `prob_func` which changes the problem. For example:
 

--- a/docs/src/tutorials/sde_example.md
+++ b/docs/src/tutorials/sde_example.md
@@ -122,6 +122,9 @@ are added via `addprocs()`, but we can change this to use multithreading via
 sol = solve(ensembleprob,EnsembleThreads(),trajectories=1000)
 ```
 
+If you use a custom noise process, you might need to specify it in a custom `prob_func`
+in the `EnsembleProblem` constructor, as each trajectory needs its own noise process.
+
 Many more controls are defined at the [Ensemble simulations page](@ref ensemble), 
 including analysis tools.
 A very simple analysis can be done with the `EnsembleSummary`, which builds

--- a/docs/src/tutorials/sde_example.md
+++ b/docs/src/tutorials/sde_example.md
@@ -120,11 +120,6 @@ are added via `addprocs()`, but we can change this to use multithreading via
 
 ```julia
 sol = solve(ensembleprob,EnsembleThreads(),trajectories=1000)
-```
-
-If you use a custom noise process, you might need to specify it in a custom `prob_func`
-in the `EnsembleProblem` constructor, as each trajectory needs its own noise process.
-
 Many more controls are defined at the [Ensemble simulations page](@ref ensemble), 
 including analysis tools.
 A very simple analysis can be done with the `EnsembleSummary`, which builds


### PR DESCRIPTION
These are minor documentation clarification concerning Ensemble problems. If an SDE problem contains a custom noise process, `safetycopy` is insufficient for properly setting up multiple trajectories. The previous version of the documentation was not clear about that, leading to confusion like this one: https://discourse.julialang.org/t/sde-ensembleproblem-unhappy-with-trajectories-2/82098