### PR TITLE
Update ensemble.md

### DIFF
--- a/docs/src/features/ensemble.md
+++ b/docs/src/features/ensemble.md
@@ -393,9 +393,11 @@ Once again, we do this with a `prob_func`, and here we modify the parameters in
 `prob.p`:
 
 ```julia
-function prob_func(prob,i,repeat)
-  x = 0.3rand(2)
-  remake(prob,p=[p[1:2];x])
+prob_func = let p=p
+    (prob,i,repeat) -> begin
+        x = 0.3rand(2)
+        remake(prob, p=[p[1], p[2], x])
+    end
 end
 ```
 

--- a/docs/src/features/ensemble.md
+++ b/docs/src/features/ensemble.md
@@ -393,6 +393,10 @@ Once again, we do this with a `prob_func`, and here we modify the parameters in
 `prob.p`:
 
 ```julia
+# `p` is a global variable, referencing it would be type unstable. 
+# Using a let block defines a small local scope in which we can
+# capture that local `p` which isn't redefined anywhere in that local scope.
+# This allows it to be type stable.
 prob_func = let p=p
     (prob,i,repeat) -> begin
         x = 0.3rand(2)


### PR DESCRIPTION
Before
```julia
julia> @time solve(ensemble_prob,SRIW1(),trajectories=10);
  6.432733 seconds (16.81 M allocations: 1.172 GiB, 6.05% gc time, 99.99% compilation time)

julia> @time solve(ensemble_prob,SRIW1(),trajectories=100_000);
  3.166502 seconds (69.13 M allocations: 6.577 GiB, 57.88% gc time)
```
After
```julia
julia> @time solve(ensemble_prob,SRIW1(),trajectories=10);
  5.336801 seconds (13.34 M allocations: 977.709 MiB, 6.05% gc time, 99.99% compilation time)

julia> @time solve(ensemble_prob,SRIW1(),trajectories=100_000);
  2.892275 seconds (68.33 M allocations: 6.527 GiB, 55.66% gc time)
```
Maybe this is too ugly, but we should at least do something about the type instability as a matter of principle.