### PR TITLE
Update ode_example.md

### DIFF
--- a/docs/src/tutorials/ode_example.md
+++ b/docs/src/tutorials/ode_example.md
@@ -1,7 +1,8 @@
 # [Ordinary Differential Equations](@id ode_example)
 
 This tutorial will introduce you to the functionality for solving ODEs. Other
-introductions can be found by [checking out SciMLTutorials.jl](https://github.com/JuliaDiffEq/SciMLTutorials.jl).
+introductions can be found by [checking out SciMLTutorials.jl](https://github.com/SciML/SciMLTutorials.jl) 
+and further resources are available at [DifferentialEquations.jl](https://diffeq.sciml.ai/stable/).
 Additionally, a [video tutorial](https://youtu.be/KPEqYtEd-zY) walks through
 this material.
 


### PR DESCRIPTION
Two very small proposed changes: there was a dead hyperlink in the first paragraph whose address was, "https://github.com/JuliaDiffEq/SciMLTutorials.jl", which has been amended to "https://github.com/SciML/SciMLTutorials.jl". 
Another possible change in the same sentence is the addition of a link to the DifferentialEquations.jl site at, "https://diffeq.sciml.ai/stable/" which I think is a great source and layout of information to link new users to but that is up to maintainers to decide.