### PR TITLE
Fix notation for non-diag. noise in SDE Solvers

### DIFF
--- a/docs/src/solvers/sde_solve.md
+++ b/docs/src/solvers/sde_solve.md
@@ -199,16 +199,16 @@ For `SRA` and `SRI`, the following option is allowed:
 - `SROCKEM` - is fixed step Euler-Mayurama with first order ROCK stabilization thus can
   handle stiff problems. Only for Ito problems. Defaults to strong and weak order 1.0,
   but can solve with weak order 0.5 as `SROCKEM(strong_order_1=false)`. This method can handle
-  1-dimensional, diagonal and multi-dimensional noise.
+  1-dimensional, diagonal and non-diagonal noise.
 - `SROCK2` - is a weak second order and strong first order fixed step stabilized method for
-  stiff Ito problems.This method can handle 1-dimensional, diagonal and multi-dimensional noise.
+  stiff Ito problems.This method can handle 1-dimensional, diagonal and non-diagonal noise.
 - `SKSROCK` - is fixed step stabilized explicit method for stiff Ito problems. Strong order 0.5
   and weak order 1. This method has a better stability domain then `SROCK1`. Also it allows
   special post-processing techniques in case of ergodic dynamical systems, in the context of
   ergodic Brownian dynamics, to achieve order 2 accuracy. `SKSROCK(;post_processing=true)`
   will make use of post processing. By default it doesn't use post processing. Post processing is
   optional and under development. The rest of the method is completely functional and can handle
-  1-dimensional, diagonal and multi-dimensional noise.  
+  1-dimensional, diagonal and non-diagonal noise.  
 - `TangXiaoSROCK2` - is a fixed step size stabilized expicit method for stiff problems. Only for
   Ito problems. Weak order of 2 and strog order of 1. Has 5 versions with different stability
   domains which can be used as `TangXiaoSROCK2(version_num=i)` where `i` is 1-5. Under Development.


### PR DESCRIPTION
This replaces the term `multi-dimensional` by `non-diagonal` noise for the SROCK solvers.

Everywhere else only `non-diagonal` is used so I suspect they are equivalent?

