### PR TITLE
Update callback_library.md

### DIFF
--- a/docs/src/features/callback_library.md
+++ b/docs/src/features/callback_library.md
@@ -4,4 +4,4 @@ DiffEqCallbacks.jl provides a library of various helpful callbacks which
 can be used with any component solver which implements the callback interface.
 It adds the following callbacks which are available to users of DifferentialEquations.jl.
 
-For information, see [the DiffEqCallbacks documentation](diffeqcallbacks.sciml.ai).
+For information, see [the DiffEqCallbacks documentation](https://docs.sciml.ai/DiffEqCallbacks/stable/).


### PR DESCRIPTION
Point DiffEqCallbacks link back to SciMLDocs

## Problem Description

After navigating to `Solvers > Equation Solvers > DifferentialEquations` section, **Additional Features** page, **Callback Library** section, the link back to DiffEqCallbacks doesn't link correctly to the new documentation (it just gives a 404 error).