### PR TITLE
Add docs for DPRKN5 and ERKN7

### DIFF
--- a/docs/src/solvers/dynamical_solve.md
+++ b/docs/src/solvers/dynamical_solve.md
@@ -85,10 +85,14 @@ steps are computed lazily (i.e. not during the solve).
 - `ERKN5`: 5th order Runge-Kutta-Nyström method which integrates the periodic
   properties of the harmonic oscillator exactly. Gets extra efficiency on periodic
   problems.
+- `ERKN7`: 7th order Runge-Kutta-Nyström method which integrates the periodic
+  properties of the harmonic oscillator exactly. Gets extra efficiency on periodic
+  problems.
 - `Nystrom4VelocityIndependent`: 4th order explicit Runge-Kutta-Nyström method.
   Fixed timestep only.
 - `Nystrom5VelocityIndependent`: 5th order explicit Runge-Kutta-Nyström method.
   Fixed timestep only.
+- `DPRKN5`: 5th order explicit adaptive Runge-Kutta-Nyström method.
 - `DPRKN6`: 6th order explicit adaptive Runge-Kutta-Nyström method. Free 6th
   order interpolant.
 - `DPRKN8`: 8th order explicit adaptive Runge-Kutta-Nyström method.


### PR DESCRIPTION
In PR [OrdinaryDiffEq.jl#1831](https://github.com/SciML/OrdinaryDiffEq.jl/pull/1831) and PR [OrdinaryDiffEq.jl#1832](https://github.com/SciML/OrdinaryDiffEq.jl/pull/1832), new Runge-Kutta-Nyström methods DPRKN5 and ERKN7 are added.

This PR adds the corresponding docs.