### PR TITLE
Update DAE Problems documentation

### DIFF
--- a/docs/src/types/dae_types.md
+++ b/docs/src/types/dae_types.md
@@ -18,10 +18,7 @@ Examples problems can be found in [DiffEqProblemLibrary.jl](https://github.com/S
 To use a sample problem, such as `prob_dae_resrob`, you can do something like:
 
 ```julia
-#] add DiffEqProblemLibrary
-using DiffEqProblemLibrary.DAEProblemLibrary
-# load problems
-DAEProblemLibrary.importdaeproblems()
+using DiffEqProblemLibrary.DAEProblemLibrary, Sundials
 prob = DAEProblemLibrary.prob_dae_resrob
 sol = solve(prob,IDA())
 ```


### PR DESCRIPTION
Fixes `importdaeproblems not defined` error. `DAEProblemLibrary` does not export this function. 

Made the doc more self-sustained by adding `using Sundials`.