### PR TITLE
Add docs for SIR54, CG4a and Alshina methods

### DIFF
--- a/docs/src/features/ensemble.md
+++ b/docs/src/features/ensemble.md
@@ -30,12 +30,12 @@ EnsembleProblem(prob::DEProblem;
     `rerun` was true this will be `2`, `3`, etc. counting the number of times
     problem `i` has been repeated.
   - `reduction`: This function determines how to reduce the data in each batch.
-    Defaults to appending the `data` into `u`, initialised via `u_data`, from 
-    the batches. `I` is a range of indices giving the trajectories corresponding 
-    to the batches. The second part of the output determines whether the simulation 
-    has converged. If `true`, the simulation will exit early. By default, this is 
+    Defaults to appending the `data` into `u`, initialised via `u_data`, from
+    the batches. `I` is a range of indices giving the trajectories corresponding
+    to the batches. The second part of the output determines whether the simulation
+    has converged. If `true`, the simulation will exit early. By default, this is
     always `false`.
-  - `u_init`: The initial form of the object that gets updated in-place inside the 
+  - `u_init`: The initial form of the object that gets updated in-place inside the
     `reduction` function.
   - `safetycopy`: Determines whether a safety `deepcopy` is called on the `prob`
     before the `prob_func`. By default, this is true for any user-given `prob_func`,

--- a/docs/src/solvers/dae_solve.md
+++ b/docs/src/solvers/dae_solve.md
@@ -93,11 +93,11 @@ extra options for the solvers, see the ODE solver page.
   - `ROS34PW3` - A 4th order strongly A-stable (Rinf~0.63) Rosenbrock-W method.
 
 !!! note
-
-  `Rosenbrock23` and `Rosenbrock32` have a stiff-aware interpolation but this interpolation is not safe for the algebraic variables.
-  Thus use the interpolation (thus `saveat`) with caution if the default Hermite interpolation is used.
-
     
+
+`Rosenbrock23` and `Rosenbrock32` have a stiff-aware interpolation but this interpolation is not safe for the algebraic variables.
+Thus use the interpolation (thus `saveat`) with caution if the default Hermite interpolation is used.
+
 #### FIRK Methods
 
   - `RadauIIA5` - An A-B-L stable fully implicit Runge-Kutta method with internal

--- a/docs/src/solvers/dynamical_solve.md
+++ b/docs/src/solvers/dynamical_solve.md
@@ -19,6 +19,7 @@ These correspond to partitioned equations of motion:
 ```
 
 or, for `SecondOrderODEProblem`,
+
 ```math
 \frac{d^2u}{dt^2} = f(u,p,t)
 ```

--- a/docs/src/solvers/nonautonomous_linear_ode.md
+++ b/docs/src/solvers/nonautonomous_linear_ode.md
@@ -125,6 +125,7 @@ These methods can be used when ``A`` is dependent on the state variables, i.e. `
   - `RKMK4` - Fourth order Runge–Kutta–Munthe-Kaas method.
   - `LieRK4` - Fourth order Lie Runge-Kutta method.
   - `CG2` - Second order Crouch–Grossman method.
+  - `CG4a` - Fourth order Crouch-Grossman method.
   - `MagnusAdapt4` - Fourth Order Adaptive Magnus method.
 
 Example:

--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -177,6 +177,10 @@ problems.
   - `MSRK5` - Stepanov 5th-order Runge-Kutta method.
   - `MSRK6` - Stepanov 6th-order Runge-Kutta method.
   - `Stepanov5` - Stepanov adaptive 5th-order Runge-Kutta method.
+  - `SIR54` - 5th order explicit Runge-Kutta method suited for SIR-type epidemic models.
+  - `Alshina2` - Alshina 2nd-order Runge-Kutta method.
+  - `Alshina3` - Alshina 3rd-order Runge-Kutta method.
+  - `Alshina6` - Alshina 6th-order Runge-Kutta method.
 
 Example usage:
 


### PR DESCRIPTION
Track https://github.com/SciML/OrdinaryDiffEq.jl/pull/1888, https://github.com/SciML/OrdinaryDiffEq.jl/pull/1921 and https://github.com/SciML/OrdinaryDiffEq.jl/pull/1898