### PR TITLE
updating path for biojulia reference

### DIFF
--- a/docs/src/tutorials/faster_ode_example.md
+++ b/docs/src/tutorials/faster_ode_example.md
@@ -13,7 +13,7 @@ list:
 
   - [The Julia Performance Tips](https://docs.julialang.org/en/v1/manual/performance-tips/)
   - [MIT 18.337 Course Notes on Optimizing Serial Code](https://mitmath.github.io/18337/lecture2/optimizing)
-  - [What scientists must know about hardware to write fast code](https://biojulia.net/post/hardware/)
+  - [What scientists must know about hardware to write fast code](https://biojulia.dev/post/hardware/)
 
 User-side optimizations are important because, for sufficiently difficult problems,
 most time will be spent inside your `f` function, the function you are


### PR DESCRIPTION
Link was broken on valuable resource, I would've left it alone but it took me a couple googles to find.
old link: https://biojulia.net/post/hardware/
new link: https://biojulia.dev/post/hardware/