### PR TITLE
Updating documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 
-DiffEqDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the documentation for the common user interface](http://docs.juliadiffeq.org/dev/). Users interested in using
+DiffEqDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the documentation for the common user interface](http://docs.sciml.ai/dev/). Users interested in using
 these features should check out [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl).

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 
-DiffEqDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the documentation for the common user interface](http://docs.sciml.ai/stable). Users interested in using
+DiffEqDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the documentation for the common user interface](http://docs.sciml.ai). Users interested in using
 these features should check out [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl).

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 
-DiffEqDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the documentation for the common user interface](http://docs.sciml.ai). Users interested in using
+DiffEqDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the documentation for the common user interface](https://docs.sciml.ai/DiffEqDocs/stable/). Users interested in using
 these features should check out [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl).

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 
-DiffEqDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the documentation for the common user interface](http://docs.sciml.ai/dev/). Users interested in using
+DiffEqDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the documentation for the common user interface](http://docs.sciml.ai/stable). Users interested in using
 these features should check out [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl).


### PR DESCRIPTION
The link in the README points to the old documentation URL. This PR updates the documentation link to `sciml.ai`. I get a "Forbidden Code" when I try to access the development version of the docs, I assume that's intentional? I'm going to remove the `/dev` suffix from the URL too.