### PR TITLE
changes Scholz47 to Scholz4_7 to match the method name in OrdinaryDiffEq

### DIFF
--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -558,7 +558,7 @@ to be thread safe. It parallelizes the `nlsolve` calls inside the method.
     and it is recommended to use `ROS2S` instead.
   - `ROS3PR` - A 3nd order stiffly accurate Rosenbrock-Wanner method
     with 3 internal stages and B_PR consistent of order 3, which is strongly A-stable with Rinf~=-0.73.
-  - `Scholz47` - A 3nd order stiffly accurate Rosenbrock-Wanner method
+  - `Scholz4_7` - A 3nd order stiffly accurate Rosenbrock-Wanner method
     with 3 internal stages and B_PR consistent of order 3, which is strongly A-stable with Rinf~=-0.73.
     Convergence with order 4 for the stiff case, but has a poor accuracy.
   - `ROS3PRL` - A 3nd order stiffly accurate Rosenbrock-Wanner method with 4 internal stages


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
