### PR TITLE
fix link to Sundials in split ODE solver docs

### DIFF
--- a/docs/src/solvers/split_ode_solve.md
+++ b/docs/src/solvers/split_ode_solve.md
@@ -44,7 +44,7 @@ the problem, though for large enough PDEs the `ARKODE` method with
 
   - `ARKODE`: An additive Runge-Kutta method. Order between 3rd and 5th. For a list
     of available options, please see
-    [its ODE solver page](https://diffeq.sciml.ai/dev/solvers/ode_solve/#ode_solve_sundials).
+    [its ODE solver page](https://docs.sciml.ai/DiffEqDocs/dev/api/sundials/).
 
 ## Semilinear ODE
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
