### PR TITLE
fix: Update sde_example.md

### DIFF
--- a/docs/src/tutorials/sde_example.md
+++ b/docs/src/tutorials/sde_example.md
@@ -317,7 +317,7 @@ function f(du, u, p, t)
 end
 function g(du, u, p, t)
     du[1] = √u[2] * u[1]
-    du[2] = Θ * √u[2]
+    du[2] = σ * √u[2]
 end
 ```
 


### PR DESCRIPTION
I believe there's a small mistake in this example as the equation uses `σ` but in the code we use `θ` (in two places instead of one).

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

I fixed the consistency with the equations but the functions don't actually make much sense as I see it as `f` and `g` should really be using `p` instead of some global variables `μ`, `κ`, `θ`, `σ` if I'm not mistaken.
