### PR TITLE
Correct physics of C14 example

### DIFF
--- a/docs/src/examples/classical_physics.md
+++ b/docs/src/examples/classical_physics.md
@@ -15,14 +15,14 @@ using OrdinaryDiffEq, Plots
 gr()
 
 #Half-life of Carbon-14 is 5,730 years.
-C₁ = 5.730
+t½ = 5.730
 
 #Setup
 u₀ = 1.0
-tspan = (0.0, 1.0)
+tspan = (0.0, 30.0)
 
 #Define the problem
-radioactivedecay(u, p, t) = -C₁ * u
+radioactivedecay(u, p, t) = -log(2) / t½ * u
 
 #Pass to solver
 prob = ODEProblem(radioactivedecay, u₀, tspan)
@@ -30,9 +30,9 @@ sol = solve(prob, Tsit5())
 
 #Plot
 plot(sol, linewidth = 2, title = "Carbon-14 half-life",
-    xaxis = "Time in thousands of years", yaxis = "Percentage left",
+    xaxis = "Time in thousands of years", yaxis = "Ratio left",
     label = "Numerical Solution")
-plot!(sol.t, t -> exp(-C₁ * t), lw = 3, ls = :dash, label = "Analytical Solution")
+plot!(sol.t, t -> 2^(-t / t½), lw = 3, ls = :dash, label = "Analytical Solution")
 ```
 
 ## Second Order Linear ODE


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The code example about radioactive isotopes does not correctly represent the physics. They decay as $2^{-t / t_{1/2}}$, not $\exp(-t \times t_{1/2})$.
This PR corrects the differential equation and the analytical solution.
Also, the vertical axis of the plot is not in percentage.

(Radioactive decay is a quantum phenomenon, by the way :) )