### PR TITLE
Add alias specifier docstrings to problem type pages 

### DIFF
--- a/docs/src/types/bvp_types.md
+++ b/docs/src/types/bvp_types.md
@@ -10,6 +10,12 @@ SciMLBase.SecondOrderBVProblem
 `BVProblem` solutions return an `ODESolution`. For more information, see the
 [ODE problem definition page](@ref ode_prob) for the `ODESolution` docstring.
 
+## Alias Specifier
+
+```@docs
+SciMLBase.BVPAliasSpecifier
+```
+
 ## Example Problems
 
 Example problems can be found in [DiffEqProblemLibrary.jl](https://github.com/SciML/DiffEqProblemLibrary.jl/blob/master/lib/BVProblemLibrary/src/BVProblemLibrary.jl).

--- a/docs/src/types/dae_types.md
+++ b/docs/src/types/dae_types.md
@@ -11,6 +11,12 @@ SciMLBase.DAEFunction
 SciMLBase.DAESolution
 ```
 
+## Alias Specifier
+
+```@docs
+SciMLBase.DAEAliasSpecifier
+```
+
 ## Example Problems
 
 Examples problems can be found in [DiffEqProblemLibrary.jl](https://github.com/SciML/DiffEqProblemLibrary.jl/tree/master/lib/DAEProblemLibrary).

--- a/docs/src/types/dde_types.md
+++ b/docs/src/types/dde_types.md
@@ -10,6 +10,12 @@ SciMLBase.DDEFunction
 `DDEProblem` solutions return an `ODESolution`. For more information, see the
 [ODE problem definition page](@ref ode_prob) for the `ODESolution` docstring.
 
+## Alias Specifier 
+
+```@docs
+SciMLBase.DDEAliasSpecifier
+```
+
 ## Example Problems
 
 Example problems can be found in [DiffEqProblemLibrary.jl](https://github.com/SciML/DiffEqProblemLibrary.jl/blob/master/lib/DDEProblemLibrary/src/DDEProblemLibrary.jl).

--- a/docs/src/types/ode_types.md
+++ b/docs/src/types/ode_types.md
@@ -11,6 +11,12 @@ SciMLBase.ODEFunction
 SciMLBase.ODESolution
 ```
 
+## ODE Alias Specifier
+
+```@docs
+SciMLBase.ODEAliasSpecifier
+```
+
 ## Example Problems
 
 Example problems can be found in [DiffEqProblemLibrary.jl](https://github.com/SciML/DiffEqProblemLibrary.jl/tree/master/lib/ODEProblemLibrary/src).

--- a/docs/src/types/rode_types.md
+++ b/docs/src/types/rode_types.md
@@ -10,3 +10,9 @@ SciMLBase.RODEFunction
 ```@docs
 SciMLBase.RODESolution
 ```
+
+## Alias Specifier
+
+```@docs
+SciMLBase.RODEAliasSpecifier
+```

--- a/docs/src/types/sdde_types.md
+++ b/docs/src/types/sdde_types.md
@@ -9,3 +9,10 @@ SciMLBase.SDDEFunction
 
 `SDDEProblem` solutions return an `RODESolution`. For more information, see the
 [RODE problem definition page](@ref rode_problem) for the `RODESolution` docstring.
+
+
+## Alias Specifier
+
+```@docs
+SciMLBase.SDDEAliasSpecifier
+```

--- a/docs/src/types/sde_types.md
+++ b/docs/src/types/sde_types.md
@@ -10,6 +10,12 @@ SciMLBase.SDEFunction
 `SDEProblem` solutions return an `RODESolution`. For more information, see the
 [RODE problem definition page](@ref rode_problem) for the `RODESolution` docstring.
 
+## Alias Specifier
+
+```@docs
+SciMLBase.SDEAliasSpecifier
+```
+
 ## Example Problems
 
 Examples problems can be found in [DiffEqProblemLibrary.jl](https://github.com/SciML/DiffEqProblemLibrary.jl/blob/master/lib/SDEProblemLibrary/src/SDEProblemLibrary.jl).

--- a/docs/src/types/steady_state_types.md
+++ b/docs/src/types/steady_state_types.md
@@ -14,3 +14,9 @@ SciMLBase.SteadyStateProblem
 ```@docs
 SciMLBase.NonlinearSolution
 ```
+
+## Alias Specifier
+
+```@docs
+SciMLBase.SteadyStateAliasSpecifier
+```


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
