### PR TITLE
Add StochasticDiffEq.jl API documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,23 @@ if isdir(ordinartdiffeq_docs_path)
     cp(common_first_steps_file, common_first_steps_dest, force=true)
 end
 
+# Copy StochasticDiffEq.jl documentation
+stochasticdiffeq_docs_root = joinpath(dirname(pathof(StochasticDiffEq)), "..", "docs")
+stochasticdiffeq_docs_path = joinpath(stochasticdiffeq_docs_root, "src")
+if isdir(stochasticdiffeq_docs_path)
+    # Create the StochasticDiffEq API directory in the docs
+    stochastic_diffeq_dest = joinpath(@__DIR__, "src", "api", "stochasticdiffeq")
+    mkpath(dirname(stochastic_diffeq_dest))
+    
+    # Copy all the docs from StochasticDiffEq.jl
+    cp(stochasticdiffeq_docs_path, stochastic_diffeq_dest, force=true)
+    
+    # Copy the pages.jl file from StochasticDiffEq.jl
+    stochastic_diffeq_pages_dest = joinpath(@__DIR__, "stochasticdiffeq_pages.jl")
+    stochastic_diffeq_pages_file = joinpath(stochasticdiffeq_docs_root, "pages.jl")
+    cp(stochastic_diffeq_pages_file, stochastic_diffeq_pages_dest, force=true)
+end
+
 ENV["PLOTS_TEST"] = "true"
 ENV["GKSwstype"] = "100"
 

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -26,6 +26,33 @@ end
 
 ordinary_diffeq_pages = transform_ordinarydiffeq_pages(pages)
 
+# Load StochasticDiffEq pages - if available
+stochastic_diffeq_pages_file = joinpath(@__DIR__, "stochasticdiffeq_pages.jl")
+stochastic_diffeq_pages = []
+if isfile(stochastic_diffeq_pages_file)
+    include(stochastic_diffeq_pages_file)
+    
+    # Transform StochasticDiffEq pages to have the api/stochasticdiffeq prefix
+    function transform_stochasticdiffeq_pages(pages_array)
+        transformed = []
+        for page in pages_array
+            if isa(page, String)
+                push!(transformed, "api/stochasticdiffeq/" * page)
+            elseif isa(page, Pair)
+                key, value = page
+                if isa(value, String)
+                    push!(transformed, key => "api/stochasticdiffeq/" * value)
+                elseif isa(value, Vector)
+                    push!(transformed, key => transform_stochasticdiffeq_pages(value))
+                end
+            end
+        end
+        return transformed
+    end
+    
+    stochastic_diffeq_pages = transform_stochasticdiffeq_pages(pages)
+end
+
 pages = Any["index.md",
     "getting_started.md",
     "Tutorials" => Any["tutorials/faster_ode_example.md",
@@ -94,4 +121,5 @@ pages = Any["index.md",
     "External Solver APIs" => Any["api/sundials.md",
         "api/daskr.md"],
     "OrdinaryDiffEq.jl API" => ordinary_diffeq_pages,
+    "StochasticDiffEq.jl API" => stochastic_diffeq_pages,
     "Extra Details" => Any["extras/timestepping.md"]]


### PR DESCRIPTION
## Summary
- Adds StochasticDiffEq.jl API documentation integration following the same pattern as the recent OrdinaryDiffEq.jl addition
- Updates `make.jl` to copy StochasticDiffEq.jl documentation during the build process
- Updates `pages.jl` to include StochasticDiffEq.jl API section in the navigation

## Context
This PR implements the StochasticDiffEq.jl API documentation integration, similar to PR #794 which added OrdinaryDiffEq.jl API docs.

## Changes
1. Modified `docs/make.jl`:
   - Added code to copy StochasticDiffEq.jl documentation to `docs/src/api/stochasticdiffeq/`
   - Copies the `pages.jl` file from StochasticDiffEq.jl as `stochasticdiffeq_pages.jl`

2. Modified `docs/pages.jl`:
   - Added loading and transformation of StochasticDiffEq pages
   - Added "StochasticDiffEq.jl API" section to the navigation structure

## Test plan
- [ ] Documentation builds successfully locally
- [ ] All StochasticDiffEq.jl API pages are accessible
- [ ] Navigation structure is correct
- [ ] No broken links in the documentation

🤖 Generated with [Claude Code](https://claude.ai/code)