### PR TITLE
Truncate long solve output in documentation

### DIFF
--- a/docs/src/features/ensemble.md
+++ b/docs/src/features/ensemble.md
@@ -414,7 +414,11 @@ Now we solve the problem 10 times and plot all of the trajectories in phase spac
 
 ```@example ensemble2
 ensemble_prob = DE.EnsembleProblem(prob, prob_func = prob_func)
-sim = DE.solve(ensemble_prob, DE.SRIW1(), trajectories = 10)
+sim = DE.solve(ensemble_prob, DE.SRIW1(), trajectories = 10);
+nothing # hide
+```
+
+```@example ensemble2
 import Plots;
 Plots.plot(sim, linealpha = 0.6, color = :blue, idxs = (0, 1), title = "Phase Space Plot");
 Plots.plot!(sim, linealpha = 0.6, color = :red, idxs = (0, 2), title = "Phase Space Plot")
@@ -531,7 +535,9 @@ explicitly give a `dt`.
 
 ```@example ensemble4
 prob2 = DE.EnsembleProblem(prob)
-sim = DE.solve(prob2, DE.SRIW1(), dt = 1 // 2^(3), trajectories = 10, adaptive = false)
+sim = DE.solve(prob2, DE.SRIW1(), dt = 1 // 2^(3), trajectories = 10, adaptive = false);
+@info "Ensemble solution computed with $(length(sim)) trajectories" # hide
+nothing # hide
 ```
 
 **Note that if you don't do the `timeseries_steps` calculations, this code is

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -78,8 +78,7 @@ function in order to speed up the solvers. These are detailed
 After defining a problem, you solve it using `solve`.
 
 ```@example ODE2
-sol = DE.solve(prob);
-nothing # hide
+sol = DE.solve(prob)
 ```
 
 This gives us an object `sol` which contains the solution. Looking at the solution object:

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -78,7 +78,20 @@ function in order to speed up the solvers. These are detailed
 After defining a problem, you solve it using `solve`.
 
 ```@example ODE2
-sol = DE.solve(prob)
+sol = DE.solve(prob);
+nothing # hide
+```
+
+This gives us an object `sol` which contains the solution. Looking at the solution object:
+
+```@example ODE2
+typeof(sol)
+```
+
+The solution object contains the time points and corresponding solution values:
+
+```@example ODE2
+@info "Solution contains $(length(sol.t)) time points from t=$(sol.t[1]) to t=$(sol.t[end])"
 ```
 
 The solvers can be controlled using the available options are described on the
@@ -87,7 +100,8 @@ we can lower the relative tolerance (in order to get a more correct result, at
 the cost of more timesteps) by using the command `reltol`:
 
 ```@example ODE2
-sol = DE.solve(prob, reltol = 1e-6)
+sol = DE.solve(prob, reltol = 1e-6);
+nothing # hide
 ```
 
 There are many controls for handling outputs. For example, we can choose to have
@@ -95,7 +109,8 @@ the solver save every `0.1` time points by setting `saveat=0.1`. Chaining this
 with the tolerance choice looks like:
 
 ```@example ODE2
-sol = DE.solve(prob, reltol = 1e-6, saveat = 0.1)
+sol = DE.solve(prob, reltol = 1e-6, saveat = 0.1);
+nothing # hide
 ```
 
 More generally, `saveat` can be any collection of time points to save at.
@@ -104,7 +119,8 @@ up the solution. In addition, if we only care about the endpoint, we can turn
 off intermediate saving in general:
 
 ```@example ODE2
-sol = DE.solve(prob, reltol = 1e-6, save_everystep = false)
+sol = DE.solve(prob, reltol = 1e-6, save_everystep = false);
+nothing # hide
 ```
 
 which will only save the final time point.
@@ -122,7 +138,8 @@ For example, if we have a stiff problem where we need high accuracy,
 but don't know the best stiff algorithm for this problem, we can use:
 
 ```@example ODE2
-sol = DE.solve(prob, alg_hints = [:stiff], reltol = 1e-8, abstol = 1e-8)
+sol = DE.solve(prob, alg_hints = [:stiff], reltol = 1e-8, abstol = 1e-8);
+nothing # hide
 ```
 
 You can also explicitly choose the algorithm to use. DifferentialEquations.jl
@@ -132,7 +149,8 @@ been shown to be more efficient than the “standard” algorithms.
 For example, we can choose a 5th order Tsitouras method:
 
 ```@example ODE2
-sol = DE.solve(prob, DE.Tsit5())
+sol = DE.solve(prob, DE.Tsit5());
+nothing # hide
 ```
 
 Note that the solver controls can be combined with the algorithm choice. Thus
@@ -140,7 +158,8 @@ we can for example solve the problem using `DE.Tsit5()` with a lower tolerance
 via:
 
 ```@example ODE2
-sol = DE.solve(prob, DE.Tsit5(), reltol = 1e-8, abstol = 1e-8)
+sol = DE.solve(prob, DE.Tsit5(), reltol = 1e-8, abstol = 1e-8);
+nothing # hide
 ```
 
 In DifferentialEquations.jl, some good “go-to” choices for ODEs are:
@@ -282,6 +301,8 @@ u0 = [1.0; 0.0; 0.0]
 tspan = (0.0, 100.0)
 prob = DE.ODEProblem(lorenz!, u0, tspan)
 sol = DE.solve(prob)
+@info "Solution has $(length(sol.t)) timesteps" # hide
+nothing # hide
 ```
 
 Using the plot recipe tools

--- a/docs/src/tutorials/dde_example.md
+++ b/docs/src/tutorials/dde_example.md
@@ -109,7 +109,9 @@ To solve the problem with this algorithm, we do the same thing we'd do with othe
 methods on the common interface:
 
 ```@example dde
-sol = DDE.solve(prob, alg)
+sol = DDE.solve(prob, alg);
+@info "Solution computed with $(length(sol.t)) timesteps" # hide
+nothing # hide
 ```
 
 Note that everything available to OrdinaryDiffEq.jl can be used here, including
@@ -202,7 +204,8 @@ from above with residual control:
 ```@example dde
 prob = DDE.DDEProblem(bc_model, u0, h, tspan)
 alg = DDE.MethodOfSteps(DE.RK4())
-sol = DDE.solve(prob, alg)
+sol = DDE.solve(prob, alg);
+nothing # hide
 ```
 
 Note that this method can solve problems with state-dependent delays.
@@ -222,7 +225,8 @@ dependent lags and solving with a `MethodOfSteps` algorithm:
 ```@example dde
 prob = DDE.DDEProblem(bc_model, u0, h, tspan; dependent_lags = ((u, p, t) -> tau,))
 alg = DDE.MethodOfSteps(DE.Tsit5())
-sol = DDE.solve(prob, alg)
+sol = DDE.solve(prob, alg);
+nothing # hide
 ```
 
 Here, we treated the single lag `t-tau` as a state-dependent delay. Of course, you

--- a/docs/src/tutorials/sde_example.md
+++ b/docs/src/tutorials/sde_example.md
@@ -37,7 +37,11 @@ The `solve` interface is then the same as ODEs. Here, we will use the classic
 Euler-Maruyama algorithm `EM` and plot the solution:
 
 ```@example sde
-sol = SDE.solve(prob, SDE.EM(), dt = dt)
+sol = SDE.solve(prob, SDE.EM(), dt = dt);
+nothing # hide
+```
+
+```@example sde
 import Plots
 Plots.plot(sol)
 ```
@@ -60,7 +64,11 @@ prob = SDE.SDEProblem(ff, u₀, (0.0, 1.0))
 We can now compare the `SDE.EM()` solution with the analytic one:
 
 ```@example sde
-sol = SDE.solve(prob, SDE.EM(), dt = dt)
+sol = SDE.solve(prob, SDE.EM(), dt = dt);
+nothing # hide
+```
+
+```@example sde
 Plots.plot(sol, plot_analytic = true)
 ```
 
@@ -69,7 +77,11 @@ the higher order methods are adaptive. Let's first switch off adaptivity and
 compare the numerical and analytic solutions :
 
 ```@example sde
-sol = SDE.solve(prob, SDE.SRIW1(), dt = dt, adaptive = false)
+sol = SDE.solve(prob, SDE.SRIW1(), dt = dt, adaptive = false);
+nothing # hide
+```
+
+```@example sde
 Plots.plot(sol, plot_analytic = true)
 ```
 
@@ -77,14 +89,22 @@ Now, let's allow the solver to automatically determine a starting `dt`. This est
 at the beginning is conservative (small) to ensure accuracy.
 
 ```@example sde
-sol = SDE.solve(prob, SDE.SRIW1())
+sol = SDE.solve(prob, SDE.SRIW1());
+nothing # hide
+```
+
+```@example sde
 Plots.plot(sol, plot_analytic = true)
 ```
 
 We can instead start the method with a larger `dt` by passing it to `solve`:
 
 ```@example sde
-sol = SDE.solve(prob, SDE.SRIW1(), dt = dt)
+sol = SDE.solve(prob, SDE.SRIW1(), dt = dt);
+nothing # hide
+```
+
+```@example sde
 Plots.plot(sol, plot_analytic = true)
 ```
 
@@ -105,7 +125,9 @@ are added via `addprocs()`, but we can change this to use multithreading via
 `SDE.EnsembleThreads()`. Together, this looks like:
 
 ```@example sde
-sol = SDE.solve(ensembleprob, SDE.EnsembleThreads(), trajectories = 1000)
+sol = SDE.solve(ensembleprob, SDE.EnsembleThreads(), trajectories = 1000);
+@info "Ensemble solution computed with $(length(sol)) trajectories" # hide
+nothing # hide
 ```
 
 !!! warn
@@ -166,7 +188,11 @@ function g!(du, u, p, t)  # It actually represents a diagonal matrix [3.0 0 0; 0
 end
 
 prob_sde_lorenz = SDE.SDEProblem(f!, g!, [1.0, 0.0, 0.0], (0.0, 10.0))
-sol = SDE.solve(prob_sde_lorenz)
+sol = SDE.solve(prob_sde_lorenz);
+nothing # hide
+```
+
+```@example sde
 Plots.plot(sol, idxs = (1, 2, 3))
 ```
 
@@ -202,7 +228,11 @@ u0 = rand(4, 2)
 
 W = SDE.WienerProcess(0.0, 0.0, 0.0)
 prob = SDE.SDEProblem(f!, g!, u0, (0.0, 1.0), noise = W)
-sol = SDE.solve(prob, SDE.SRIW1())
+sol = SDE.solve(prob, SDE.SRIW1());
+nothing # hide
+```
+
+```@example sde
 Plots.plot(sol)
 ```
 


### PR DESCRIPTION
## Summary
This PR addresses issue #718 by truncating long output from `solve()` calls in the documentation to reduce excessive vertical scrolling.

## Changes
- Added semicolons to suppress verbose solve output display
- Added `nothing # hide` comments to prevent output from showing in rendered docs
- Split solve and plot commands into separate code blocks for better readability
- Added informative messages for some outputs (e.g., ensemble solutions)

## Files Modified
- `docs/src/getting_started.md` - Main getting started guide
- `docs/src/tutorials/sde_example.md` - SDE tutorial
- `docs/src/tutorials/dde_example.md` - DDE tutorial  
- `docs/src/features/ensemble.md` - Ensemble simulations documentation

## Example
Before:
```julia
sol = DE.solve(prob)
# Long output with arrays of numbers...
```

After:
```julia
sol = DE.solve(prob);
nothing # hide
```

## Testing
The documentation should build successfully with these changes, and the solve outputs will no longer display long arrays of numbers in the rendered documentation.

Fixes #718

🤖 Generated with [Claude Code](https://claude.ai/code)