### PR TITLE
Complete DiffEqOperators deprecation updates

### DIFF
--- a/docs/src/examples/beeler_reuter.md
+++ b/docs/src/examples/beeler_reuter.md
@@ -92,6 +92,11 @@ end
 
 The finite-difference Laplacian is calculated in-place by a 5-point stencil. The Neumann boundary condition is enforced.
 
+!!! note
+    For more complex PDE discretizations, consider using [MethodOfLines.jl](https://docs.sciml.ai/MethodOfLines/stable/) 
+    which can automatically generate finite difference discretizations, or [SciMLOperators.jl](https://docs.sciml.ai/SciMLOperators/stable/) 
+    for defining matrix-free linear operators.
+
 ```julia
 # 5-point stencil
 function laplacian(Δu, u)

--- a/docs/src/features/diffeq_operator.md
+++ b/docs/src/features/diffeq_operator.md
@@ -1,6 +1,6 @@
-# Matrix-Free Linear Operators and Specializations on Linearity
+# Matrix-Free Linear Operators with SciMLOperators.jl
 
-SciML has the [SciMLOpereators.jl](https://docs.sciml.ai/SciMLOperators/stable/) library for defining linear operators.
-The ODE solvers will specialize on this property, for example using the lienar operators automatically with Newton-Krylov
-methods for matrix-free Newton-Krylov optimzations, but also allows for methods that requires knowing that part of the
+SciML has the [SciMLOperators.jl](https://docs.sciml.ai/SciMLOperators/stable/) library for defining linear operators.
+The ODE solvers will specialize on this property, for example using the linear operators automatically with Newton-Krylov
+methods for matrix-free Newton-Krylov optimizations, but also allows for methods that require knowing that part of the
 equation is linear, like exponential integrators. See the SciMLOperators.jl library for more information.


### PR DESCRIPTION
## Summary
This PR completes the deprecation of DiffEqOperators in the documentation as requested in issue #678.

## Changes
1. **Fixed typos in `diffeq_operator.md`**:
   - `Opereators` → `Operators`
   - `lienar` → `linear`
   - `optimzations` → `optimizations`
   - `requires` → `require`

2. **Updated page title**:
   - Changed from "Matrix-Free Linear Operators and Specializations on Linearity"
   - To "Matrix-Free Linear Operators with SciMLOperators.jl"

3. **Added note in `beeler_reuter.md`**:
   - Added a note in the Laplacian section suggesting MethodOfLines.jl and SciMLOperators.jl as alternatives to manual implementation

4. **Verified `diffusion_implicit_heat_equation.md`**:
   - Already uses SciMLOperators.jl (no changes needed)

5. **Searched for remaining references**:
   - No other references to DiffEqOperators found in the documentation

## Checklist from issue #678
- [x] Replace with SciMLOperators (diffeq_operator.md already referenced it, just fixed typos)
- [x] Mention MOL instead (added note in beeler_reuter.md)
- [x] To SciMLOps (diffusion_implicit_heat_equation.md already uses it)
- [x] Search for other mentions (none found)

Fixes #678

🤖 Generated with [Claude Code](https://claude.ai/code)