### PR TITLE
Fix missing multiplication operator in pendulum example

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -379,7 +379,7 @@ end
 u₀ = [θ₀, ω₀]                       # initial state vector
 tspan = (0.0, 10.0)                  # time interval
 
-M = t -> 0.1sin(t)                    # external torque [Nm]
+M = t -> 0.1 * sin(t)                    # external torque [Nm]
 
 prob = DE.ODEProblem(pendulum!, u₀, tspan, M)
 sol = DE.solve(prob)


### PR DESCRIPTION
## Summary
This PR fixes a syntax error in the getting started documentation where a multiplication operator was missing between a numeric literal and a function call.

## Problem
In the pendulum example, the external torque was defined as:
```julia
M = t -> 0.1sin(t)
```

This is invalid Julia syntax. While you can write `2x` for multiplication with variables, you cannot write `0.1sin(t)` - you need an explicit multiplication operator between a numeric literal and a function call.

## Solution
Fixed the syntax to:
```julia
M = t -> 0.1 * sin(t)
```

## Impact
This fixes a syntax error that would cause the code example to fail when users try to execute it, improving the user experience when following the getting started tutorial.

🤖 Generated with [Claude Code](https://claude.ai/code)