### PR TITLE
Document how to mutate parameters p in integrator

### DIFF
--- a/docs/src/basics/integrator.md
+++ b/docs/src/basics/integrator.md
@@ -144,6 +144,13 @@ As low-level alternative to the callbacks, one can use `set_t!`, `set_u!` and
 have efficient ways to modify `u` and `t`.  In such case, `set_*!` are as
 inefficient as `reinit!`.
 
+For modifying parameters `p`, you can directly assign to the field:
+```julia
+integrator.p = new_p
+```
+Unlike `u` or `t`, changing `p` doesn't affect the solver's internal state or
+accuracy, so it can be modified directly without a setter function.
+
 ```@docs
 SciMLBase.set_t!
 SciMLBase.set_u!


### PR DESCRIPTION
## Summary
This PR adds documentation explaining how to modify parameters `p` in the integrator interface, addressing issue #243.

## Problem
Users were unclear on how to change the differential equation parameters during integration. While the documentation showed `set_t\!`, `set_u\!`, and `set_ut\!` for modifying state variables, it didn't explain how to modify parameters.

## Solution
Added a clear explanation in the integrator documentation that parameters can be modified directly via:
```julia
integrator.p = new_p
```

The documentation also explains why this is different from `u` and `t` - changing `p` doesn't affect the solver's internal state or accuracy, so it can be modified directly without a setter function.

## Context
As confirmed by @ChrisRackauckas in the issue comments, parameters can be directly assigned unlike `u` or `t`. The callback documentation already shows examples of this pattern being used in `affect\!` functions.

Fixes #243

🤖 Generated with [Claude Code](https://claude.ai/code)