### PR TITLE
Fix typos and syntax errors in documentation

### DIFF
--- a/docs/src/basics/faq.md
+++ b/docs/src/basics/faq.md
@@ -179,7 +179,7 @@ for automatically transforming your equations.
 
 ### I'm trying to solve DAEs but my solver is unstable and/or slow, what's wrong with IDA and DFBDF?
 
-Fully implicit DAEs ``f(du,u,p,t) = 0`` are extremely difficult to numerical handle for many reasons.
+Fully implicit DAEs ``f(du,u,p,t) = 0`` are extremely difficult to numerically handle for many reasons.
 The linearly implicit form ``Mu'=f(u)`` where ``M`` is a singular mass matrix is much simpler
 numerically and thus results in much better performance. This is seen in many instances with the
 SciMLBenchmarks. Thus it is recommended that in almost all or most situations, one should use the

--- a/docs/src/features/callback_functions.md
+++ b/docs/src/features/callback_functions.md
@@ -137,7 +137,7 @@ of just `10`. This model is implemented as simply:
 ```@example callback1
 dosetimes = [4.0, 6.0, 8.0]
 condition(u, t, integrator) = t ∈ dosetimes && (u[1] < 1.0)
-affect!(integrator) = integrator.u[1] += 10integrator.t
+affect!(integrator) = integrator.u[1] += 10 * integrator.t
 cb = DE.DiscreteCallback(condition, affect!)
 sol = DE.solve(prob, DE.Tsit5(), callback = cb, tstops = dosetimes)
 Plots.plot(sol)

--- a/docs/src/tutorials/advanced_ode_example.md
+++ b/docs/src/tutorials/advanced_ode_example.md
@@ -258,7 +258,7 @@ by default). Then `newW = true` whenever a new `W` matrix is computed, and
 `newW === nothing || newW` and when true, it's only at these points when
 we update the preconditioner, otherwise we just pass on the previous version.
 We use `convert(AbstractMatrix,W)` to get the concrete `W` matrix (matching
-`jac_prototype`, thus `SpraseMatrixCSC`) which we can use in the preconditioner's
+`jac_prototype`, thus `SparseMatrixCSC`) which we can use in the preconditioner's
 definition. Then we use `IncompleteLU.ilu` on that sparse matrix to generate
 the preconditioner. We return `Pl,nothing` to say that our preconditioner is a
 left preconditioner, and that there is no right preconditioning.


### PR DESCRIPTION
## Summary
This PR fixes several simple typos and syntax errors found in the documentation.

## Changes

### 1. Fixed typo in `docs/src/tutorials/advanced_ode_example.md`
- **Line 261**: `SpraseMatrixCSC` → `SparseMatrixCSC`
- This was a simple spelling mistake in the type name

### 2. Fixed grammar in `docs/src/basics/faq.md`
- **Line 182**: "numerical handle" → "numerically handle"
- Corrected incorrect word order (adjective used where adverb needed)

### 3. Fixed missing multiplication operator in `docs/src/features/callback_functions.md`
- **Line 140**: `10integrator.t` → `10 * integrator.t`
- Added explicit multiplication operator for better clarity and consistency

## Impact
These are minor documentation fixes that improve readability and correctness without changing any functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)