### PR TITLE
remove outdated reference to juno

### DIFF
--- a/docs/src/features/progress_bar.md
+++ b/docs/src/features/progress_bar.md
@@ -1,6 +1,6 @@
 # Progress Bar Integration
 
-DifferentialEquations.jl integrates with the Juno progress bar in order to make
+DifferentialEquations.jl integrates with the VS Code progress bar in order to make
 long calculations more manageable. By default, this feature is off for ODE and
 SDE solvers, but can be turned on via the keyword argument `progress=true`.
 The progress bar updates every `progress_steps` timesteps, which has a default


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
