### PR TITLE
Add docstring for `BVPFunction` to bvp_types.md

### DIFF
--- a/docs/src/types/bvp_types.md
+++ b/docs/src/types/bvp_types.md
@@ -3,6 +3,7 @@
 ```@docs
 SciMLBase.BVProblem
 SciMLBase.SecondOrderBVProblem
+SciMLBase.BVPFunction
 ```
 
 ## Solution Type


### PR DESCRIPTION
The docstring for `BVPFunction` currently doesn't appear anywhere on the docs site.

## Checklist

- [x] Appropriate tests were added
  None applicable
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR puts the docstring for the `BVPFunction` type in the context of the documentation website.
