### PR TITLE
Update SDDE solver docs for StochasticDelayDiffEq deprecation

### DIFF
--- a/docs/src/solvers/sdde_solve.md
+++ b/docs/src/solvers/sdde_solve.md
@@ -1,5 +1,15 @@
 # SDDE Solvers
 
+!!! note "StochasticDelayDiffEq.jl is deprecated"
+    The separate `StochasticDelayDiffEq.jl` package is deprecated as of the
+    OrdinaryDiffEq v7 / SciMLBase v3 ecosystem release. SDDE problems are now
+    solved directly via `DelayDiffEq.jl`, which has supported them for some time.
+    Replace `using StochasticDelayDiffEq` with `using DelayDiffEq` (and add
+    `using StochasticDiffEq` if you rely on SDE algorithm names such as `EM()`,
+    `RKMil()`, or `SRIW1()`). The `MethodOfSteps(alg)` wrapper and the
+    `SDDEProblem` constructor are unchanged. See the
+    [OrdinaryDiffEq v7 migration guide](@ref ordinarydiffeq_v7_migration) for details.
+
 `solve(prob::AbstractSDDEProblem, alg; kwargs)`
 
 Solves the SDDE defined by `prob` using the algorithm `alg`. If no algorithm is
@@ -8,7 +18,7 @@ given, a default algorithm will be chosen.
 ## Recommended Methods
 
 The recommended method for SDDE problems are the `SDE` algorithms. On SDEs you
-simply reuse the same algorithm as the `SDE` solver, and StochasticDelayDiffEq.jl
+simply reuse the same algorithm as the `SDE` solver, and `DelayDiffEq.jl`
 will convert it to an SDDE solver. The recommendations for SDDE solvers match
 those of SDEs, except that only up to strong order 1 is recommended. Also note
 that order 1 is currently only attainable if there is no delay term in the
@@ -23,6 +33,8 @@ technique as SDEs, but no proof of convergence is known for SDDEs.
 ## Example
 
 ```julia
+using DelayDiffEq, StochasticDiffEq
+
 function hayes_modelf(du, u, h, p, t)
     τ, a, b, c, α, β, γ = p
     du .= a .* u .+ b .* h(p, t - τ) .+ c


### PR DESCRIPTION
## Summary

The `StochasticDelayDiffEq.jl` package was deprecated in the OrdinaryDiffEq v7 / SciMLBase v3 ecosystem release. From the OrdinaryDiffEq NEWS:

> `StochasticDelayDiffEq.jl` is deprecated. Use `DelayDiffEq.jl` directly — it has supported SDDE problems for some time, and the separate `StochasticDelayDiffEq` wrapper is no longer being maintained. It will not receive a v7-compatible release.
>
> **Migration:** replace `using StochasticDelayDiffEq` with `using DelayDiffEq` (plus `using StochasticDiffEq` if you were relying on the SDE algorithm re-exports). `MethodOfSteps(alg)` and the `SDDEProblem` constructor continue to work from `DelayDiffEq` / `SciMLBase` respectively.

This PR updates `docs/src/solvers/sdde_solve.md` to reflect that change.

## Changes

**`docs/src/solvers/sdde_solve.md`**
- Added a `!!! note` admonition at the top of the page explaining the deprecation of `StochasticDelayDiffEq.jl`, the migration path (`using DelayDiffEq` + `using StochasticDiffEq` for SDE algorithm names), and a link to the [OrdinaryDiffEq v7 migration guide](ordinarydiffeq_v7_migration).
- Replaced the inline mention of `StochasticDelayDiffEq.jl` in the Recommended Methods section with `DelayDiffEq.jl`.
- Added `using DelayDiffEq, StochasticDiffEq` to the example code block (`RKMil()` comes from `StochasticDiffEq`; `SDDEProblem` and `solve` come from `DelayDiffEq`/`SciMLBase`).

The `MethodOfSteps(alg)` wrapper and the `SDDEProblem` constructor are **unchanged** — this is purely a package-import update. The SDDE page is kept (SDDE problems still exist as a topic).

No other files contained `using StochasticDelayDiffEq` in docs/; the migration guide already has the canonical deprecation note.

## Test plan

- [ ] Documenter CI build passes (checks for broken `@ref` links and renders the admonition correctly)
- [ ] Verify `@ref ordinarydiffeq_v7_migration` resolves to the migration guide page

🤖 Generated with [Claude Code](https://claude.com/claude-code)