### PR TITLE
Re-instantiate Pkg registry in Documentation.yml

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -24,12 +24,16 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
+      - name: Set up Julia registries
+        shell: julia --color=yes --project=docs {0}
+        run: using Pkg; Pkg.Registry.rm("General"); Pkg.Registry.add()
+        env:
+          JULIA_PKG_SERVER: ''
       - name: Set up environment
         shell: julia --color=yes --project=docs {0}
         run: |
           println("--- Instantiating project")
           using Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
           println("--- Adding OrdinaryDiffEq from master")
           Pkg.develop("OrdinaryDiffEq")


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Maybe that will fix the GitHub workflow's problem on resolving versions when building docs (https://github.com/SciML/DiffEqDocs.jl/actions/runs/26536151206/job/78165442948). First waiting on the CI checks to see if it even works, because on a local machine I was unable to reproduce the error.