### PR TITLE
Normalize CI to SciML centralized reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,26 @@
+name: "Downgrade"
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "docs/**"
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  downgrade:
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,22 +1,18 @@
-name: format-check
+name: "Format Check"
 
 on:
   push:
     branches:
-      - 'master'
-      - 'main'
-      - 'release-'
-    tags: '*'
+      - master
+    tags: ["*"]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,13 +1,9 @@
-name: Spell Check
+name: "Spell Check"
 
 on: [pull_request]
 
 jobs:
-  typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+  spellcheck:
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,0 +1,31 @@
+name: "Tests"
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "docs/**"
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  tests:
+    name: "Tests"
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1"
+          - "lts"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+    secrets: "inherit"

--- a/.typos.toml
+++ b/.typos.toml
@@ -2,3 +2,5 @@
 quations = "quations"
 IIF = "IIF"
 padd = "padd"
+thr = "thr"
+SIE = "SIE"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Normalizes this repo's CI to the SciML centralized reusable workflows (`SciML/.github/.github/workflows/*.yml@v1`, every caller pinned `@v1` with `secrets: inherit`).

## Workflows converted
- **FormatCheck.yml** -> calls `runic.yml@v1` (previously an inline `fredrikekre/runic-action@v1` job). The repo was already Runic-enforced and is already formatted; running `Runic --check` locally on `src`, `test`, `docs/make.jl`, `docs/pages.jl` produced no diff, so no formatting commit was needed.
- **SpellCheck.yml** -> calls `spellcheck.yml@v1` (previously inline `crate-ci/typos@v1.18.0`). The centralized caller uses a newer typos version.

## Workflows added (standard set)
- **Tests.yml** -> calls `tests.yml@v1` with a `["1","lts"]` version matrix. The repo had no test workflow but is a testable package (`test/runtests.jl` runs ExplicitImports checks), so a minimal caller was added. No `GROUP` is used.
- **Downgrade.yml** -> calls `downgrade.yml@v1` (`julia-version: lts`, `skip: Pkg,TOML`). None existed previously.

Tests and Downgrade are gated with `paths-ignore: docs/**` so doc-only PRs don't trigger the package test/downgrade runs.

## Left unchanged (intentionally)
- **Documentation.yml** — NOT migrated. This workflow runs on `[self-hosted, gpu-v100]` and includes a custom `Pkg.develop("OrdinaryDiffEq")` step so the docs are built against OrdinaryDiffEq's master, plus `DATADEPS_ALWAYS_ACCEPT`/draft-PR gating. `documentation.yml@v1` cannot reproduce the specific GPU runner label or the extra `develop` step, so migrating it would silently drop required behavior. Left as-is to preserve the docs build.
- **TagBot.yml** — unchanged (standard JuliaRegistries/TagBot).

## dependabot.yml
- Removed the `crate-ci/typos` version-update ignore block (standing policy: keep everything current, no per-dependency ignores).
- Preserved the existing `julia` block (`/`, `/docs`, `/test`, daily, grouped `all-julia-packages: ["*"]`) and the `github-actions` block (`/`, weekly).

## CompatHelper
- None present; nothing to remove.

## Spellcheck findings
Adding `thr` and `SIE` (code identifiers / a solver name) to `.typos.toml` as clear false positives. Two **real** typos remain and are intentionally left for a maintainer to fix (not mass-editing prose here) — the SpellCheck job will flag them:
- `docs/src/examples/classical_physics.md:268` — `Contiunous` should be `Continuous` (in a code comment)
- `docs/src/solvers/bvp_solve.md:102` — `prblem` should be `problem`

**The SpellCheck check will be RED until those two typos are fixed.**

## Heads-up on branch protection
Check names change (e.g. job names now come from the centralized callers). **Branch-protection required-status-checks must be updated** to the new check names, or merges will be blocked waiting on stale required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)