### PR TITLE
docs: use AlgebraicMultigrid's automatic (SPQR) coarse solver

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -90,7 +90,7 @@ DiffEqDocs = {path = ".."}
 
 [compat]
 ADTypes = "1.7"
-AlgebraicMultigrid = "0.5, 0.6, 1, 2"
+AlgebraicMultigrid = "2"
 BSON = "0.3"
 BVProblemLibrary = "0.1.2"
 BenchmarkTools = "1"

--- a/docs/src/tutorials/advanced_ode_example.md
+++ b/docs/src/tutorials/advanced_ode_example.md
@@ -274,10 +274,7 @@ which is more automatic. The setup is very similar to before:
 import AlgebraicMultigrid
 function algebraicmultigrid(W, p)
     A = convert(AbstractMatrix, W)
-    # Use a direct (LU) coarse solver: AlgebraicMultigrid's default `Pinv` coarse solver
-    # forms a dense pseudo-inverse via SVD, which errors on the non-SPD `W = I - γJ`.
-    Pl = AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(A;
-        coarse_solver = AlgebraicMultigrid.LinearSolveWrapper(LS.UMFPACKFactorization())))
+    Pl = AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(A))
     Pl, LinearAlgebra.I
 end
 
@@ -294,8 +291,7 @@ function algebraicmultigrid2(W, p)
     A = convert(AbstractMatrix, W)
     Pl = AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(A,
         presmoother = AlgebraicMultigrid.Jacobi(rand(size(A, 1))),
-        postsmoother = AlgebraicMultigrid.Jacobi(rand(size(A, 1))),
-        coarse_solver = AlgebraicMultigrid.LinearSolveWrapper(LS.UMFPACKFactorization())))
+        postsmoother = AlgebraicMultigrid.Jacobi(rand(size(A, 1)))))
     Pl, LinearAlgebra.I
 end
 


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

Follow-up to #869/#870. Now that **AMG v2.0 is installable alongside the OrdinaryDiffEq v7 stack** (via SciML/LinearSolve.jl#1047, released as LinearSolve **3.85.2**, which bumps the AMG-extension weak compat to `"1, 2"`), this drops the `coarse_solver = LinearSolveWrapper(UMFPACKFactorization())` override from the AMG preconditioner examples in `advanced_ode_example.md` and uses `ruge_stuben`'s **default** coarse solver.

## Why

The UMFPACK (LU) override was a workaround for **AMG 1.x's** default `Pinv` coarse solver, which forms a dense SVD pseudo-inverse and errored (`gesdd!` "invalid argument") on the non-SPD `W = I - γJ` coarse-grid matrix.

**AMG 2.0's default coarse solver is `QRSolver`** (`qr()` → SuiteSparse **SPQR** for sparse matrices), which handles the non-SPD / rank-deficient coarse operator robustly with no override. LU is itself the wrong tool here (less robust than QR on near-singular coarse matrices), so the default is both cleaner and more correct.

Because `docs/Manifest.toml` is resolved fresh on each build (it is git-ignored) and `docs/Project.toml` allows `AlgebraicMultigrid = "0.5, 0.6, 1, 2"` + `LinearSolve = "2, 3"`, the build now resolves **LinearSolve 3.85.2 → AlgebraicMultigrid 2.0.0** automatically.

## Verification (local, released stack)

- Registry-only resolution (fresh General from the pkg server, no dev checkout): `OrdinaryDiffEq 7.0.0 + LinearSolve 3.85.2 + AlgebraicMultigrid 2.0.0`.
- `KenCarp47(linsolve = KrylovJL_GMRES(precs = ...), concrete_jac = true)` on the brusselator solves successfully with `ruge_stuben` using the **default** coarse solver — both the plain and Jacobi-smoothed variants — on AMG 2.0.0. No `gesdd!`, no override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)