### PR TITLE
docs CI: add KLU.jl and ForwardDiff.jl to linkcheck_ignore (fix master Documentation build)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -176,6 +176,8 @@ makedocs(
         "https://www.sciencedirect.com/science/article/pii/S0096300304009683",
         "https://github.com/JuliaDiff/FiniteDiff.jl",
         "https://github.com/SciML/LinearSolve.jl",
+        "https://github.com/JuliaSparse/KLU.jl",
+        "https://github.com/JuliaDiff/ForwardDiff.jl",
         "https://www.mathworks.com/help/matlab/math/nonnegative-ode-solution.html",
     ],
     doctest = false, clean = true,


### PR DESCRIPTION
## Problem

The `Documentation` check on `master` (HEAD `10df882`) is failing. The build terminates with:

```
ERROR: LoadError: `makedocs` encountered an error [:linkcheck] -- terminating build before rendering.
```

The culprit is GitHub rate-limiting the CI runner's IP. linkcheck repeatedly received **HTTP 429** for:

- `https://github.com/JuliaSparse/KLU.jl`
- `https://github.com/JuliaDiff/ForwardDiff.jl`

Both URLs are valid (a normal request returns 200); the 429 is transient GitHub anti-abuse throttling, not a broken link.

## Fix

Add the two throttled GitHub URLs to `linkcheck_ignore` in `docs/make.jl`. This mirrors the existing, maintainer-merged convention in this file (e.g. `FiniteDiff.jl` / `LinearSolve.jl` added in #842) of ignoring GitHub links that get throttled during linkcheck.

## Local verification

On Julia 1.12.6 (the "1" CI channel), parsed `docs/make.jl` and evaluated the literal `linkcheck_ignore` vector, then reproduced Documenter's ignore-matching (`url == entry` for string entries):

```
linkcheck_ignore length = 29
https://github.com/JuliaSparse/KLU.jl       ignored=true
https://github.com/JuliaDiff/ForwardDiff.jl ignored=true
https://github.com/JuliaDiff/FiniteDiff.jl  ignored=true   (pre-existing, sanity)
https://github.com/SciML/SomethingNotIgnored.jl ignored=false  (control)
```

So linkcheck will skip exactly these two URLs and no longer hit the 429 that terminated the build. Runic reports no formatting changes.

---

Please ignore until reviewed by @ChrisRackauckas
