### PR TITLE
docs CI: fix gh-pages deploy (GITHUB_TOKEN write permissions, drop broken DOCUMENTER_KEY)

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -18,6 +18,10 @@ jobs:
     name: "Documentation"
     runs-on: [self-hosted, gpu-v100]
     timeout-minutes: 360
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     if: github.event_name == 'push' || !github.event.pull_request.draft
     steps:
       - uses: actions/checkout@v6
@@ -38,6 +42,5 @@ jobs:
         run: julia --color=yes --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           DATADEPS_ALWAYS_ACCEPT: true
           JULIA_DEBUG: "Documenter"


### PR DESCRIPTION
## Problem

The `Documentation` workflow's docs **build passes**, but the `deploydocs` gh-pages push fails. Two compounding causes:

1. The `build-and-deploy` job had **no `permissions:` block**, so the `GITHUB_TOKEN` flowing into the job is read-only and cannot push to `gh-pages`.
2. The build step injected `DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}`. When that env var is present, Documenter's `deploydocs` takes the **SSH** deploy path (`git@github.com:...`), which fails with `Permission denied (publickey)` because the deploy key is missing/invalid.

## Fix (YAML-only)

- Add a `permissions:` block to the `build-and-deploy` job:
  ```yaml
  permissions:
    actions: write
    contents: write
    statuses: write
  ```
  This mirrors the proven pattern from SciML/OrdinaryDiffEqOperatorSplitting.jl #90.
- Remove `DOCUMENTER_KEY` from the build step's `env`. With no `DOCUMENTER_KEY` present, `deploydocs` auto-falls back to pushing over **HTTPS using `GITHUB_TOKEN`**, which the new `contents: write` permission now authorizes. `GITHUB_TOKEN` is retained in the env. **No secret is required.**

`deploydocs(repo = "github.com/SciML/DiffEqDocs.jl.git")` in `docs/make.jl` is already the HTTPS form, so the token path works as-is.

## Verification

YAML validated with `python3` (`yaml.safe_load`) — parses cleanly; `permissions` resolves to `{actions: write, contents: write, statuses: write}`. The full deploy cannot be verified without a CI run (it requires the self-hosted runner + a push to `master`), but the change matches the proven #90 pattern and the documented Documenter token-deploy fallback.

This does **not** disable the docs check or set `warnonly`.

Please ignore until reviewed by @ChrisRackauckas