### PR TITLE
Fix master docs build: resolve upstream @ref cross-references (#879)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,6 +48,24 @@ if isdir(ordinartdiffeq_docs_path)
     # OrdinaryDiffEq's developer docs are contributor-internal and their @eval blocks
     # read paths relative to OrdinaryDiffEq's own build layout, so they cannot build
     # inside DiffEqDocs; drop them from the user-facing site.
+    # Bare `@ref Developer-Extension-API` links in the copied API pages target the
+    # deleted developer docs; rewrite them to the published OrdinaryDiffEq page so
+    # Documenter cross-references stay resolvable here (see SciML/DiffEqDocs.jl#879).
+    for (root, _, files) in walkdir(ordinary_diffeq_dest)
+        for file in files
+            endswith(file, ".md") || continue
+            path = joinpath(root, file)
+            text = read(path, String)
+            new_text = replace(
+                text,
+                r"\[([^\]]*)\]\(@ref Developer-Extension-API\)" =>
+                    s"[\1](https://docs.sciml.ai/OrdinaryDiffEq/stable/devtools/internals/public_api/)",
+            )
+            if new_text != text
+                write(path, new_text)
+            end
+        end
+    end
     rm(joinpath(ordinary_diffeq_dest, "devtools"), recursive = true, force = true)
 
     # Copy the pages.jl file from OrdinaryDiffEq.jl

--- a/docs/src/basics/integrator.md
+++ b/docs/src/basics/integrator.md
@@ -87,6 +87,8 @@ and then `solve!` is equivalent to `solve`.
 SciMLBase.step!
 SciMLBase.check_error
 SciMLBase.check_error!
+SciMLBase.ReturnCode
+SciMLBase.reeval_internals_due_to_modification!
 ```
 
 ## Handling Integrators

--- a/docs/src/features/dae_initialization.md
+++ b/docs/src/features/dae_initialization.md
@@ -29,6 +29,7 @@ DiffEqBase.NoInit
 DiffEqBase.OverrideInit
 DiffEqBase.BrownFullBasicInit
 DiffEqBase.ShampineCollocationInit
+SciMLBase.OverrideInitData
 ```
 
 ## ⚠️ WARNING: NoInit Usage

--- a/docs/src/types/bvp_types.md
+++ b/docs/src/types/bvp_types.md
@@ -4,6 +4,7 @@
 SciMLBase.BVProblem
 SciMLBase.SecondOrderBVProblem
 SciMLBase.BVPFunction
+SciMLBase.problem_type
 ```
 
 ## Solution Type


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes #879.

## Problem

Master Documentation fails with `makedocs encountered an error [:cross_references]`. Bare `@ref`s live inside **upstream** SciMLBase / OrdinaryDiffEq docstrings spliced via `@docs` without local targets.

Broken refs (from run 29313032312):

- `problem_type`, `OverrideInitData`, `ReturnCode`, `reeval_internals_due_to_modification!` (SciMLBase)
- `Developer-Extension-API` ×3 (OrdinaryDiffEq API pages; target lives under `devtools/`, which DiffEqDocs deletes)

## Fix

1. Add `@docs` entries for the four SciMLBase names in the appropriate local pages.
2. Before deleting `devtools/`, rewrite copied `[...](@ref Developer-Extension-API)` links to the published OrdinaryDiffEq `public_api` URL.

Does **not** add `:cross_references` to `warnonly`.