### PR TITLE
Document DABDF2/ABDF2 order-2 local error control (OrdinaryDiffEq#1256)

### DIFF
--- a/docs/src/basics/faq.md
+++ b/docs/src/basics/faq.md
@@ -406,6 +406,30 @@ is 1-2 digits less than the relative tolerances. Thus, for the defaults
 digits. This is standard across the board and applies to the native Julia methods,
 the wrapped Fortran and C++ methods, the calls to MATLAB/Python/R, etc.
 
+#### [Why does adaptive `DABDF2` / `ABDF2` give global error much larger than `tol`?](@id faq_dabdf2_error_control)
+
+`DABDF2` (fully implicit DAEs) and its ODE twin `ABDF2` are **fixed order-2**
+methods that adapt the timestep using a **local** order-2 error estimate. Local
+tolerances are not global guarantees (see the previous FAQ entry). For fixed-order
+local-error control of order ``p = 2``, standard theory gives:
+
+  - stepsize ``h \sim \mathrm{tol}^{1/(p+1)} = \mathrm{tol}^{1/3}``
+  - global error ``O(h^p) \sim \mathrm{tol}^{p/(p+1)} = \mathrm{tol}^{2/3}``
+  - so ``\mathrm{global\ error}/\mathrm{tol} \sim \mathrm{tol}^{-1/3}``
+
+Absolute error still decreases as you tighten `abstol`/`reltol`, but the ratio
+of global error to tolerance can grow by about a factor of ``100^{1/3} \approx 4.6``
+each time the tolerance is tightened by ``100\times``. That growth is expected for
+order-2 local control; it is not evidence of a broken error estimator.
+
+If you need global error that tracks the requested tolerances more tightly:
+
+  - for fully implicit DAEs (`DAEProblem`), prefer `DFBDF` (variable-order adaptive BDF)
+  - for ODEs, prefer higher-order multistep methods such as `FBDF` or `QNDF`
+
+See [SciML/OrdinaryDiffEq.jl#1256](https://github.com/SciML/OrdinaryDiffEq.jl/issues/1256)
+for measurements and discussion.
+
 #### The solver doesn't obey physical law X (e.g. conservation of energy)
 
 Yes, this is because the numerical solution of the ODE is not the exact solution.

--- a/docs/src/solvers/dae_solve.md
+++ b/docs/src/solvers/dae_solve.md
@@ -64,6 +64,11 @@ These methods from OrdinaryDiffEq are for `DAEProblem` specifications.
 
   - `OrdinaryDiffEqBDF.DImplicitEuler` - 1st order A-L and stiffly stable adaptive implicit Euler
   - `OrdinaryDiffEqBDF.DABDF2` - 2nd order A-L stable adaptive BDF method.
+    Fixed order-2 local-error control: global ``\mathrm{err}/\mathrm{tol}`` can grow
+    like ``\mathrm{tol}^{-1/3}`` as tolerances tighten (see
+    [the FAQ](@ref faq_dabdf2_error_control) and
+    [OrdinaryDiffEq.jl#1256](https://github.com/SciML/OrdinaryDiffEq.jl/issues/1256)).
+    Prefer `DFBDF` when global error should track `tol` more tightly.
   - `OrdinaryDiffEqBDF.DFBDF` - A fixed-leading coefficient adaptive-order adaptive-time BDF method,
     similar to `ode15i` or `IDA` in divided differences form.
 

--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -815,7 +815,11 @@ Sundials CVODE integrator.
   - `OrdinaryDiffEqBDF.QBDF1` - An adaptive order 1 L-stable BDF method. This is equivalent to
     implicit Euler but using the BDF error estimator.
   - `OrdinaryDiffEqBDF.ABDF2` - An adaptive order 2 L-stable fixed leading coefficient multistep
-    BDF method.
+    BDF method. Fixed order-2 local-error control: global ``\mathrm{err}/\mathrm{tol}``
+    can grow like ``\mathrm{tol}^{-1/3}`` as tolerances tighten (see
+    [the FAQ](@ref faq_dabdf2_error_control) and
+    [OrdinaryDiffEq.jl#1256](https://github.com/SciML/OrdinaryDiffEq.jl/issues/1256)).
+    Prefer `FBDF` or `QNDF` when global error should track `tol` more tightly.
   - `OrdinaryDiffEqBDF.QNDF2` - An adaptive order 2 quasi-constant timestep L-stable numerical
     differentiation function (NDF) method.
   - `OrdinaryDiffEqBDF.QBDF2` - An adaptive order 2 L-stable BDF method using quasi-constant timesteps.


### PR DESCRIPTION
## Summary

Documents the residual adaptive behavior of `DABDF2` / `ABDF2` after the diagnosis of [SciML/OrdinaryDiffEq.jl#1256](https://github.com/SciML/OrdinaryDiffEq.jl/issues/1256): these methods use **fixed order-2 local-error control**, so global `err/tol` can grow like `tol^{-1/3}` as tolerances tighten. Absolute error still improves; the ratio growth is expected theory, not a broken estimator.

Changes:
- FAQ entry under Numerical Error (`faq_dabdf2_error_control`) explaining the local vs global scaling and recommending `DFBDF` (DAEs) or `FBDF`/`QNDF` (ODEs)
- Short notes on the `DABDF2` listing in DAE solver docs and `ABDF2` in ODE solver docs, linking the FAQ and #1256

No solver code changes; docs-only follow-up to the #1256 diagnosis.

## Related

- SciML/OrdinaryDiffEq.jl#1256
- Diagnosis: residual high err/tol is expected for fixed order-2 local control; formula/FSAL issues already addressed by #3995

## Notes for reviewers

**Please ignore this PR until reviewed by @ChrisRackauckas.**