### PR TITLE
Add auxiliary variables in equation of motion

### DIFF
--- a/docs/src/examples/classical_physics.md
+++ b/docs/src/examples/classical_physics.md
@@ -218,15 +218,17 @@ end
 
 #Define the Problem
 function double_pendulum(xdot, x, p, t)
-    xdot[1] = x[2]
-    xdot[2] = -((g * (2 * m₁ + m₂) * sin(x[1]) +
-                 m₂ * (g * sin(x[1] - 2 * x[3]) +
-                  2 * (L₂ * x[4]^2 + L₁ * x[2]^2 * cos(x[1] - x[3])) * sin(x[1] - x[3]))) /
-                (2 * L₁ * (m₁ + m₂ - m₂ * cos(x[1] - x[3])^2)))
-    xdot[3] = x[4]
-    xdot[4] = (((m₁ + m₂) * (L₁ * x[2]^2 + g * cos(x[1])) +
-                L₂ * m₂ * x[4]^2 * cos(x[1] - x[3])) * sin(x[1] - x[3])) /
-              (L₂ * (m₁ + m₂ - m₂ * cos(x[1] - x[3])^2))
+    θ₁, ω₁, θ₂, ω₂ = x
+    Δθ = θ₁ - θ₂
+    sΔ, cΔ = sincos(Δθ)
+    xdot[1] = ω₁
+    xdot[2] = -((g * (2m₁ + m₂) * sin(θ₁) +
+                 m₂ * g * sin(θ₁ - 2θ₂) +
+                 2m₂ * (L₂ * ω₂^2 + L₁ * ω₁^2 * cΔ) * sΔ) /
+                (2L₁ * (m₁ + m₂ * sΔ^2)))
+    xdot[3] = ω₂
+    xdot[4] = ((m₁ + m₂) * (L₁ * ω₁^2 + g * cos(θ₁)) + L₂ * m₂ * ω₂^2 * cΔ) * sΔ /
+              (L₂ * (m₁ + m₂ * sΔ^2))
 end
 
 #Pass to Solvers


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Uses θ and ω instead of α, β, lα, lβ because the original definition does not match the previous LaTeX block anyway. The current form of the code should hopefully be easier to parse as mathematical equations.

This also makes use of the identity $\sin²(x) + \cos²(x) = 1$ to turn $m₂ - m₂ \cos²(Δθ)$ to $m₂ \sin²(Δθ)$.
