### PR TITLE
Fix backtick usage in dassl.md and simplediffeq.md

### DIFF
--- a/docs/src/api/dassl.md
+++ b/docs/src/api/dassl.md
@@ -18,7 +18,7 @@ These methods can be used independently of the rest of DifferentialEquations.jl.
 
 The following DAE solver is available:
 
-  - ``dassl`` - A native Julia implementation of the DASSL algorithm. This is an
+  - `dassl` - A native Julia implementation of the DASSL algorithm. This is an
     adaptive-order, adaptive-stepsize backward differentiation formula (BDF)
     method for solving stiff systems of differential-algebraic equations.
 

--- a/docs/src/api/simplediffeq.md
+++ b/docs/src/api/simplediffeq.md
@@ -18,21 +18,21 @@ import SimpleDiffEq
 
 The following ODE solvers are available:
 
-  - ``SimpleTsit5`` - A fixed timestep integrator form of Tsit5. Not compatible with events.
-  - ``SimpleATsit5`` - An adaptive Tsit5 with an interpolation in its simplest form. Not compatible with events.
-  - ``GPUSimpleATsit5`` - A version of SimpleATsit5 without the integrator interface. Only allows `solve`.
-  - ``SimpleEuler`` - A fixed timestep bare-bones Euler implementation with integrators.
-  - ``SimpleRK4`` - A fixed timestep bare-bones RK4 implementation with integrators.
-  - ``GPUSimpleVern7`` - A fully static Vern7 for specialized compilation to accelerators like GPUs and TPUs.
-  - ``GPUSimpleVern9`` - A fully static Vern9 for specialized compilation to accelerators like GPUs and TPUs.
-  - ``GPUSimpleTsit5`` - A fully static Tsit5 for specialized compilation to accelerators.
-  - ``GPUSimpleRK4`` - A fully static RK4 for specialized compilation to accelerators.
-  - ``GPUSimpleEuler`` - A fully static Euler for specialized compilation to accelerators.
-  - ``LoopEuler`` - A fixed timestep bare-bones Euler. Not compatible with events or the integrator interface.
-  - ``LoopRK4`` - A fixed timestep bare-bones RK4. Not compatible with events or the integrator interface.
+  - `SimpleTsit5` - A fixed timestep integrator form of Tsit5. Not compatible with events.
+  - `SimpleATsit5` - An adaptive Tsit5 with an interpolation in its simplest form. Not compatible with events.
+  - `GPUSimpleATsit5` - A version of SimpleATsit5 without the integrator interface. Only allows `solve`.
+  - `SimpleEuler` - A fixed timestep bare-bones Euler implementation with integrators.
+  - `SimpleRK4` - A fixed timestep bare-bones RK4 implementation with integrators.
+  - `GPUSimpleVern7` - A fully static Vern7 for specialized compilation to accelerators like GPUs and TPUs.
+  - `GPUSimpleVern9` - A fully static Vern9 for specialized compilation to accelerators like GPUs and TPUs.
+  - `GPUSimpleTsit5` - A fully static Tsit5 for specialized compilation to accelerators.
+  - `GPUSimpleRK4` - A fully static RK4 for specialized compilation to accelerators.
+  - `GPUSimpleEuler` - A fully static Euler for specialized compilation to accelerators.
+  - `LoopEuler` - A fixed timestep bare-bones Euler. Not compatible with events or the integrator interface.
+  - `LoopRK4` - A fixed timestep bare-bones RK4. Not compatible with events or the integrator interface.
 
 ## SDE Solvers
 
 The following SDE solvers are available:
 
-  - ``SimpleEM`` - A fixed timestep solve method for Euler-Maruyama. Only works with non-colored Gaussian noise.
+  - `SimpleEM` - A fixed timestep solve method for Euler-Maruyama. Only works with non-colored Gaussian noise.


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Double backticks are seen as enclosing (La/Ka)TeX code by Documenter.jl and Julia-flavored markdown.
