### PR TITLE
Separate out precompilation step in Documentation.yml

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -38,6 +38,14 @@ jobs:
         env:
           DATADEPS_ALWAYS_ACCEPT: true
           JULIA_PKG_PRECOMPILE_AUTO: 0
+      - name: Precompile environment
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          println("--- Precompiling project")
+          using Pkg
+          Pkg.precompile()
+        env:
+          DATADEPS_ALWAYS_ACCEPT: true
       - name: Building documentation
         run: julia --color=yes --project=docs docs/make.jl
         env:


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Move precompilation logging statements out of main docs build, since that's populated by debug messages from Documenter.jl
