### PR TITLE
Document NordsieckBDF and DNordsieckBDF as recommended BDF methods

### DIFF
--- a/docs/src/solvers/dae_solve.md
+++ b/docs/src/solvers/dae_solve.md
@@ -6,7 +6,7 @@ The solvers on this page are distributed across the packages below. Add the pack
 
 | Package | Methods | Good for |
 |---|---|---|
-| `OrdinaryDiffEqBDF` | FBDF, QNDF, ABDF2, SBDF, DFBDF, DImplicitEuler | Stiff large/sparse mass-matrix or implicit-form DAEs. |
+| `OrdinaryDiffEqBDF` | NordsieckBDF, FBDF, QNDF, ABDF2, SBDF, DNordsieckBDF, DFBDF, DImplicitEuler | Stiff large/sparse mass-matrix or implicit-form DAEs. |
 | `OrdinaryDiffEqRosenbrock` | Rosenbrock23, Rodas4/5P, ROS variants | Stiff small-to-medium index-1 mass-matrix DAEs. |
 | `OrdinaryDiffEqSDIRK` | KenCarp3/4/47/58, TRBDF2, ImplicitEuler, Kvaerno | Stiff DAEs with cheap Jacobians; general fallback. |
 | `OrdinaryDiffEqFIRK` | RadauIIA3/5/9 | Stiff DAEs needing high precision (1e-10+). |
@@ -58,12 +58,17 @@ These methods from OrdinaryDiffEq are for `DAEProblem` specifications.
 
 !!! note "v8: import from `OrdinaryDiffEqBDF`"
 
-    `DImplicitEuler`, `DABDF2`, and `DFBDF` live in
+    `DImplicitEuler`, `DABDF2`, `DNordsieckBDF`, and `DFBDF` live in
     `OrdinaryDiffEqBDF` and are not in `OrdinaryDiffEq`'s default re-export
     set under v7. Load them with `using OrdinaryDiffEqBDF`.
 
   - `OrdinaryDiffEqBDF.DImplicitEuler` - 1st order A-L and stiffly stable adaptive implicit Euler
   - `OrdinaryDiffEqBDF.DABDF2` - 2nd order A-L stable adaptive BDF method.
+  - `OrdinaryDiffEqBDF.DNordsieckBDF` - The fully implicit form of `NordsieckBDF`:
+    an adaptive-order adaptive-time BDF method on a
+    propagated Nordsieck history array. The array supplies both the state predictor and
+    the derivative, so the corrector solves `f((zn[1] + l[1]*acor)/h, ypred + acor, p, t) = 0`
+    with leading coefficient `cj = l[1]/h`, the same role `cj` plays in IDA.
   - `OrdinaryDiffEqBDF.DFBDF` - A fixed-leading coefficient adaptive-order adaptive-time BDF method,
     similar to `ode15i` or `IDA` in divided differences form.
 

--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -25,7 +25,7 @@ The solvers on this page are distributed across the packages below. Add the pack
 | `OrdinaryDiffEqSDIRK` | KenCarp3/4/47/58, TRBDF2, ImplicitEuler, Kvaerno | Stiff problems with cheap Jacobians; general stiff fallback. |
 | `OrdinaryDiffEqFIRK` | RadauIIA3/5/9 | Stiff problems needing high precision (1e-10+) or very stiff. |
 | `OrdinaryDiffEqPDIRK` | PDIRK44 | Diagonally-implicit RK with stage parallelism. |
-| `OrdinaryDiffEqBDF` | FBDF, QNDF, ABDF2, SBDF, DFBDF, DImplicitEuler | Stiff large/sparse systems; index-1 DAEs (mass-matrix or implicit). |
+| `OrdinaryDiffEqBDF` | NordsieckBDF, FBDF, QNDF, ABDF2, SBDF, DNordsieckBDF, DFBDF, DImplicitEuler | Stiff large/sparse systems; index-1 DAEs (mass-matrix or implicit). |
 | `OrdinaryDiffEqAdamsBashforthMoulton` | AB3-AB5, ABM, VCAB, VCABM | Non-stiff multistep on smooth, expensive RHS evaluations. |
 | `OrdinaryDiffEqNordsieck` | AN5, JVODE | Variable-step / variable-order Adams in Nordsieck form. |
 | `OrdinaryDiffEqExtrapolation` | ExtrapolationMidpoint, ImplicitHairerWanner, etc. | Smooth problems benefiting from Richardson extrapolation; very high order. |
@@ -101,8 +101,8 @@ For stiff problems at high tolerances (`>1e-2`?) it is recommended that you use
 stiffness, though are only efficient when low accuracy is needed.
 `Rosenbrock23` is more efficient for small systems where re-evaluating and
 re-factorizing the Jacobian is not too costly, and for sufficiently large
-systems `TRBDF2` will be more efficient. `QNDF` or `FBDF` can be the most efficient
-for the largest systems or most expensive `f`.
+systems `TRBDF2` will be more efficient. `NordsieckBDF`, `QNDF` or `FBDF` can be
+the most efficient for the largest systems or most expensive `f`.
 
 At medium tolerances (`>1e-8`?) it is recommended you use `Rodas5P`,
 `Rodas4P` (the former is more efficient, but the latter is more reliable),
@@ -117,9 +117,14 @@ use `radau`.
 
 For asymptotically large systems of ODEs (`N>1000`?)
 where `f` is very costly, and the complex eigenvalues are minimal (low oscillations),
-in that case `QNDF` or `FBDF` will be the most efficient.
-`QNDF` and `FBDF` will also do surprisingly well if the solution is smooth. However,
-this method can handle less stiffness than other methods and its Newton iterations
+a BDF method will be the most efficient. `NordsieckBDF` is the recommended default
+here: it is the same family as `CVODE_BDF` (a Nordsieck-array BDF following CVODE)
+and on standard stiff benchmarks it needs noticeably fewer matrix factorizations
+than `FBDF`, which is what dominates the cost once the linear solve is expensive.
+(It evaluates the Jacobian itself somewhat more often, matching `CVODE_BDF`'s
+trade-off of cheaper factorizations for fresher Jacobians.) `QNDF` and `FBDF` remain good choices and are more battle-tested.
+All of them will also do surprisingly well if the solution is smooth. However,
+these methods can handle less stiffness than other methods and their Newton iterations
 may fail at low accuracy situations. Other choices to consider in this regime are
 `CVODE_BDF` and `lsoda`.
 
@@ -203,7 +208,7 @@ problems.
     | Stabilized Explicit (ROCK*, RKC, ESERK*, ...)         | `OrdinaryDiffEqStabilizedRK` / `OrdinaryDiffEqStabilizedIRK` |
     | Implicit Extrapolation                                | `OrdinaryDiffEqExtrapolation`                    |
     | Exponential RK / EPIRK / Adaptive Exp Rosenbrock      | `OrdinaryDiffEqExponentialRK`                    |
-    | BDF / FBDF / QNDF / QBDF / DFBDF / DABDF2 / DImplicitEuler / SBDF | `OrdinaryDiffEqBDF` (FBDF re-exported by main pkg) |
+    | BDF / NordsieckBDF / FBDF / QNDF / QBDF / DNordsieckBDF / DFBDF / DABDF2 / DImplicitEuler / SBDF | `OrdinaryDiffEqBDF` (FBDF re-exported by main pkg) |
     | Implicit SSPRK                                        | `OrdinaryDiffEqSSPRK`                            |
     | Function-map / DiscreteProblem default                | `OrdinaryDiffEqFunctionMap`                      |
     | Symplectic RK (KahanLi*, McAte*, VelocityVerlet, ...) | `OrdinaryDiffEqSymplecticRK`                     |
@@ -827,6 +832,13 @@ Sundials CVODE integrator.
     stability properties over the standard BDF. Fixed timestep only.
   - `OrdinaryDiffEqBDF.FBDF` - A fixed-leading coefficient adaptive-order adaptive-time BDF method,
     similar to `ode15i` or `CVODE_BDF` in divided differences form.
+  - `OrdinaryDiffEqBDF.NordsieckBDF` - An adaptive-order adaptive-time BDF method on a
+    propagated Nordsieck history array, following `CVODE_BDF`. Because the history is
+    propagated rather than rebuilt from stored solution points, changing the step size
+    is exact and the corrector may be solved only to a fraction of the local error
+    budget (`nlsolve = NLNewton(κ = ...)` acts as CVODE's `NLSCOEF`). Dense output is
+    the Nordsieck polynomial itself and is free. Recommended for large stiff systems
+    and expensive `f`.
 
 #### Implicit Strong-Stability Preserving Runge-Kutta Methods for Hyperbolic PDEs (Conservation Laws)
 


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.** Draft.

> ⚠️ **Depends on https://github.com/SciML/OrdinaryDiffEq.jl/pull/4017** — the solvers
> documented here do not exist yet. Do not merge before that lands.

Documents the two Nordsieck BDF solvers added in OrdinaryDiffEq.jl#4017:

- **`NordsieckBDF`** — adaptive-order adaptive-time BDF on a propagated Nordsieck
  history array, following `CVODE_BDF`
- **`DNordsieckBDF`** — the fully implicit DAE form

## What changed

`docs/src/solvers/ode_solve.md`

- package overview table, and the v8 package-mapping table
- the stiff recommendations: both the high-tolerance paragraph and the
  asymptotically-large-systems paragraph
- the multistep method list

`docs/src/solvers/dae_solve.md`

- package overview table, the v8 import note, and the DAE method list

## On the recommendation wording

The large-system paragraph now leads with `NordsieckBDF`, while keeping `QNDF` and
`FBDF` alongside it and explicitly calling them more battle-tested — the new solvers
have no production mileage yet, so I did not want the docs to push people off a
well-tested method without that caveat.

The performance claim is deliberately narrow: fewer **matrix factorizations** than
`FBDF` on the standard stiff benchmarks. That is what was measured (0.68x the W
factorizations at matched accuracy over ROBER/HIRES/OREGO/POLLU/VDPOL/BRUSS1D).
I avoided claiming fewer *Jacobian evaluations*, because those are actually **higher**
(1.89x) — it is the same trade CVODE makes, cheaper factorizations for fresher
Jacobians, and the docs now say so rather than implying a uniform win.

## Not verified

I could not build the docs locally: the doc build needs the full OrdinaryDiffEq stack,
which is currently broken on master by an upstream `SciMLBase.u_cache` removal
(`invalid method definition in OrdinaryDiffEqLowOrderRK: exported function
OrdinaryDiffEqCore.u_cache does not exist`). For that reason I also avoided adding a
cross-page `@ref` link I could not check, and used plain text instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bHrkkvJzfYPMMJMRJ5GqX
