### PR TITLE
Remove duplicate naming in keyword arguments

### DIFF
--- a/docs/src/extras/timestepping.md
+++ b/docs/src/extras/timestepping.md
@@ -254,5 +254,5 @@ and used via
 
 ```julia
 import StochasticDiffEq as SDE # EM
-sol = SDE.solve(prob, SDE.EM(), dt = dt, adaptive = true, controller = CustomController())
+sol = SDE.solve(prob, SDE.EM(); dt, adaptive = true, controller = CustomController())
 ```

--- a/docs/src/features/callback_functions.md
+++ b/docs/src/features/callback_functions.md
@@ -214,11 +214,11 @@ With these functions we can build our callbacks:
 import DifferentialEquations as DE
 save_positions = (true, true)
 
-cb = DE.DiscreteCallback(condition, affect!, save_positions = save_positions)
+cb = DE.DiscreteCallback(condition, affect!; save_positions)
 
 save_positions = (false, true)
 
-cb2 = DE.DiscreteCallback(condition2, affect2!, save_positions = save_positions)
+cb2 = DE.DiscreteCallback(condition2, affect2!; save_positions)
 
 cbs = DE.CallbackSet(cb, cb2)
 ```
@@ -714,7 +714,7 @@ callback = DE.ContinuousCallback(condition, affect!)
 u0 = [0.2]
 tspan = (0.0, 10.0)
 prob = DE.ODEProblem(f, u0, tspan)
-sol = DE.solve(prob, callback = callback)
+sol = DE.solve(prob; callback)
 ```
 
 The plot recipes do not have a way of handling the changing size, but we can

--- a/docs/src/features/ensemble.md
+++ b/docs/src/features/ensemble.md
@@ -306,7 +306,7 @@ end
 Now we build and solve the `EnsembleProblem` with this base problem and `prob_func`:
 
 ```julia
-ensemble_prob = DE.EnsembleProblem(prob, prob_func = prob_func)
+ensemble_prob = DE.EnsembleProblem(prob; prob_func)
 sim = DE.solve(ensemble_prob, DE.Tsit5(), DE.EnsembleDistributed(), trajectories = 10)
 ```
 
@@ -336,7 +336,7 @@ use the `@everywhere` macro. Instead, the same problem can be implemented simply
 import DifferentialEquations as DE
 prob = DE.ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
 prob_func(prob, ctx) = DE.remake(prob, u0 = rand() * prob.u0)
-ensemble_prob = DE.EnsembleProblem(prob, prob_func = prob_func)
+ensemble_prob = DE.EnsembleProblem(prob; prob_func)
 sim = DE.solve(ensemble_prob, DE.Tsit5(), DE.EnsembleThreads(), trajectories = 10)
 import Plots;
 Plots.plot(sim);
@@ -417,7 +417,7 @@ end
 Now we solve the problem 10 times and plot all of the trajectories in phase space:
 
 ```@example ensemble2
-ensemble_prob = SDE.EnsembleProblem(prob, prob_func = prob_func)
+ensemble_prob = SDE.EnsembleProblem(prob; prob_func)
 sim = SDE.solve(ensemble_prob, SDE.SRIW1(), trajectories = 10);
 nothing # hide
 ```

--- a/docs/src/features/verbosity.md
+++ b/docs/src/features/verbosity.md
@@ -23,7 +23,7 @@ prob = ODEProblem(lorenz!, u0, tspan)
 
 # Solve with detailed verbosity
 verbose = DEVerbosity(SciMLLogging.Detailed())
-sol = solve(prob, Tsit5(), verbose = verbose)
+sol = solve(prob, Tsit5(); verbose)
 ```
 
 ## Example Use Cases
@@ -37,7 +37,7 @@ using ODEProblemLibrary: prob_ode_vanderpol_stiff
 using OrdinaryDiffEqRosenbrock: Rodas5
 
 verbose = DEVerbosity(alg_switch = SciMLLogging.InfoLevel())
-sol = solve(prob_ode_vanderpol_stiff, AutoTsit5(Rodas5()), verbose = verbose)
+sol = solve(prob_ode_vanderpol_stiff, AutoTsit5(Rodas5()); verbose)
 ```
 
 ### Monitoring Stiff Solver Performance
@@ -64,7 +64,7 @@ verbose = DEVerbosity(
     performance = SciMLLogging.InfoLevel(),
     linear_verbosity = SciMLLogging.Detailed()
 )
-sol = solve(prob, Rosenbrock23(), verbose = verbose)
+sol = solve(prob, Rosenbrock23(); verbose)
 ```
 
 ### Debugging Step Acceptance/Rejection
@@ -76,7 +76,7 @@ verbose = DEVerbosity(
     step_accepted = SciMLLogging.InfoLevel(),
     step_rejected = SciMLLogging.InfoLevel()
 )
-sol = solve(prob, Tsit5(), verbose = verbose)
+sol = solve(prob, Tsit5(); verbose)
 ```
 
 ### Silent Operation
@@ -85,7 +85,7 @@ Completely disable all output:
 
 ```julia
 verbose = DEVerbosity(SciMLLogging.None())
-solve(prob, Tsit5(), verbose = verbose)
+solve(prob, Tsit5(); verbose)
 ```
 
 ## Using with `init`
@@ -97,7 +97,7 @@ verbose = DEVerbosity(
     alg_switch = SciMLLogging.InfoLevel(),
     linear_verbosity = SciMLLogging.Detailed()
 )
-integrator = init(prob, Rosenbrock23(), verbose = verbose)
+integrator = init(prob, Rosenbrock23(); verbose)
 
 # Step through the solution
 step!(integrator)
@@ -117,7 +117,7 @@ using OrdinaryDiffEqSDIRK: ImplicitEuler
 
 # Enable detailed nonlinear solver diagnostics
 verbose = DEVerbosity(nonlinear_verbosity = SciMLLogging.Detailed())
-sol = solve(prob, ImplicitEuler(nlsolve = NonlinearSolveAlg()), verbose = verbose)
+sol = solve(prob, ImplicitEuler(nlsolve = NonlinearSolveAlg()); verbose)
 ```
 
 ### Using LinearVerbosity and NonlinearVerbosity Explicitly
@@ -136,7 +136,7 @@ nonlinear_verbosity = NonlinearVerbosity(SciMLLogging.Minimal())
 verbose = DEVerbosity(; linear_verbosity, nonlinear_verbosity)
 
 # Use with a stiff solver
-sol = solve(prob, Rosenbrock23(), verbose = verbose)
+sol = solve(prob, Rosenbrock23(); verbose)
 ```
 
 ## Combining Settings Flexibly
@@ -151,7 +151,7 @@ verbose = DEVerbosity(
     step_rejected = SciMLLogging.Silent(),
     dt_NaN = SciMLLogging.ErrorLevel()
 )
-sol = solve(prob, Tsit5(), verbose = verbose)
+sol = solve(prob, Tsit5(); verbose)
 ```
 
 ## API Reference

--- a/docs/src/tutorials/dae_example.md
+++ b/docs/src/tutorials/dae_example.md
@@ -132,7 +132,7 @@ and make the `DAEProblem`:
 
 ```@example dae
 differential_vars = [true, true, false]
-prob = DE.DAEProblem(f2, du₀, u₀, tspan, differential_vars = differential_vars)
+prob = DE.DAEProblem(f2, du₀, u₀, tspan; differential_vars)
 ```
 
 `differential_vars` is an option which states which of the variables are differential,

--- a/docs/src/tutorials/sde_example.md
+++ b/docs/src/tutorials/sde_example.md
@@ -37,7 +37,7 @@ The `solve` interface is then the same as ODEs. Here, we will use the classic
 Euler-Maruyama algorithm `EM` and plot the solution:
 
 ```@example sde
-sol = SDE.solve(prob, SDE.EM(), dt = dt);
+sol = SDE.solve(prob, SDE.EM(); dt);
 nothing # hide
 ```
 
@@ -64,7 +64,7 @@ prob = SDE.SDEProblem(ff, u₀, (0.0, 1.0))
 We can now compare the `SDE.EM()` solution with the analytic one:
 
 ```@example sde
-sol = SDE.solve(prob, SDE.EM(), dt = dt);
+sol = SDE.solve(prob, SDE.EM(); dt);
 nothing # hide
 ```
 
@@ -77,7 +77,7 @@ the higher order methods are adaptive. Let's first switch off adaptivity and
 compare the numerical and analytic solutions :
 
 ```@example sde
-sol = SDE.solve(prob, SDE.SRIW1(), dt = dt, adaptive = false);
+sol = SDE.solve(prob, SDE.SRIW1(); dt, adaptive = false);
 nothing # hide
 ```
 
@@ -100,7 +100,7 @@ Plots.plot(sol, plot_analytic = true)
 We can instead start the method with a larger `dt` by passing it to `solve`:
 
 ```@example sde
-sol = SDE.solve(prob, SDE.SRIW1(), dt = dt);
+sol = SDE.solve(prob, SDE.SRIW1(); dt);
 nothing # hide
 ```
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

If a local variable shares the same name as a keyword argument to a function call, the local variable can be passed as a keyword argument without having to duplicate the names in the call.
