### PR TITLE
Split classical_physics examples into per-topic groups

### DIFF
--- a/docs/src/examples/classical_physics.md
+++ b/docs/src/examples/classical_physics.md
@@ -12,7 +12,7 @@ If you're getting some cold feet to jump in to DiffEq land, here are some handcr
 
 The Radioactive decay problem is the first order linear ODE problem of an exponential with a negative coefficient, which represents the half-life of the process in question. Should the coefficient be positive, this would represent a population growth equation. ``λ`` is known as the decay rate, and can be related to the half-life as ``λ = \ln(2)/t_{1/2}``.
 
-```@example physics
+```@example
 import OrdinaryDiffEq as ODE, Plots
 Plots.gr()
 
@@ -70,7 +70,7 @@ with ``c_1``, ``c_2`` constants determined by the initial conditions such that
 Instead of transforming this to a system of ODEs to solve with `ODEProblem`,
 we can use `SecondOrderODEProblem` as follows.
 
-```@example physics
+```@example
 # Simple Harmonic Oscillator Problem
 import OrdinaryDiffEq as ODE
 import OrdinaryDiffEqRKN as ODERKN # DPRKN6
@@ -135,7 +135,7 @@ of first order ODEs by employing the notation ``ω(t) = \dot{θ}``.
 \end{align*}
 ```
 
-```@example physics
+```@example simple-pendulum
 # Simple Pendulum Problem
 import OrdinaryDiffEq as ODE, Plots
 
@@ -168,7 +168,7 @@ Plots.plot(
 
 So now we know that behaviour of the position versus time. However, it will be useful to us to look at the phase space of the pendulum, i.e., and representation of all possible states of the system in question (the pendulum) by looking at its velocity and position. Phase space analysis is ubiquitous in the analysis of dynamical systems, and thus we will provide a few facilities for it.
 
-```@example physics
+```@example simple-pendulum
 p = Plots.plot(
     sol, vars = (1, 2), xlims = (-9, 9), title = "Phase Space Plot",
     xaxis = "Angular position", yaxis = "Angular velocity", leg = false
@@ -203,7 +203,7 @@ its motion are given by the following (taken from this [Stack Overflow question]
 \end{pmatrix}
 ```
 
-```@example physics
+```@example double-pendulum
 #Double Pendulum Problem
 import OrdinaryDiffEq as ODE, Plots
 
@@ -252,7 +252,7 @@ double_pendulum_problem = ODE.ODEProblem(double_pendulum, initial, tspan)
 sol = ODE.solve(double_pendulum_problem, ODE.Vern7(), abstol = 1.0e-10, dt = 0.05);
 ```
 
-```@example physics
+```@example double-pendulum
 #Obtain coordinates in Cartesian Geometry
 ts, ps = polar2cart(sol, l1 = L₁, l2 = L₂, dt = 0.01)
 Plots.plot(ps...)
@@ -267,7 +267,7 @@ This helps to understand the dynamics of interactions and is wonderfully pretty.
 
 The Poincaré section in this is given by the collection of ``(β,l_β)`` when ``α=0`` and ``\frac{dα}{dt}>0``.
 
-```@example physics
+```@example double-pendulum
 #Constants and setup
 import OrdinaryDiffEq as ODE
 initial2 = [0.01, 0.005, 0.01, 0.01]
@@ -310,7 +310,7 @@ function poincare_map(prob, u₀, p; callback = cb)
 end
 ```
 
-```@example physics
+```@example double-pendulum
 lβrange = -0.02:0.0025:0.02
 p = Plots.scatter(sol2, idxs = (3, 4), leg = false, markersize = 3, msw = 0)
 for lβ in lβrange
@@ -350,7 +350,7 @@ E = T+V = V(x,y) + \frac{1}{2} \left(\dot{x}^2+\dot{y}^2\right).
 
 The total energy should conserve as this system evolves.
 
-```@example physics
+```@example henon-heiles
 import OrdinaryDiffEq as ODE, Plots
 
 #Setup
@@ -377,7 +377,7 @@ prob = ODE.ODEProblem(Hénon_Heiles, initial, tspan)
 sol = ODE.solve(prob, ODE.Vern9(), abstol = 1.0e-16, reltol = 1.0e-16);
 ```
 
-```@example physics
+```@example henon-heiles
 # Plot the orbit
 Plots.plot(
     sol, idxs = (1, 2), title = "The orbit of the Hénon-Heiles system",
@@ -385,7 +385,7 @@ Plots.plot(
 )
 ```
 
-```@example physics
+```@example henon-heiles
 #Optional Sanity check - what do you think this returns and why?
 @show sol.retcode
 
@@ -397,7 +397,7 @@ Plots.plot(
 Plots.plot!(sol, idxs = (2, 4), leg = false)
 ```
 
-```@example physics
+```@example henon-heiles
 #We map the Total energies during the time intervals of the solution (sol.u here) to a new vector
 #pass it to the plotter a bit more conveniently
 energy = map(x -> E(x...), sol.u)
@@ -416,8 +416,9 @@ Plots.plot(
 
 To prevent energy drift, we can instead use a symplectic integrator. We can directly define and solve the `SecondOrderODEProblem`:
 
-```@example physics
+```@example henon-heiles
 import OrdinaryDiffEqSymplecticRK as ODESymp # KahanLi8
+import OrdinaryDiffEqRKN as ODERKN # DPRKN6
 function HH_acceleration!(dv, v, u, p, t)
     x, y = u
     dx, dy = dv
@@ -433,7 +434,7 @@ sol2 = ODE.solve(prob, ODESymp.KahanLi8(), dt = 1 / 10);
 
 Notice that we get the same results:
 
-```@example physics
+```@example henon-heiles
 # Plot the orbit
 Plots.plot(
     sol2, idxs = (3, 4), title = "The orbit of the Hénon-Heiles system",
@@ -441,7 +442,7 @@ Plots.plot(
 )
 ```
 
-```@example physics
+```@example henon-heiles
 Plots.plot(
     sol2, idxs = (3, 1), title = "Phase space for the Hénon-Heiles system",
     xaxis = "Position", yaxis = "Velocity"
@@ -451,7 +452,7 @@ Plots.plot!(sol2, idxs = (4, 2), leg = false)
 
 but now the energy change is essentially zero:
 
-```@example physics
+```@example henon-heiles
 energy = map(x -> E(x[3], x[4], x[1], x[2]), sol2.u)
 #We use @show here to easily spot erratic behaviour in our system by seeing if the loss in energy was too great.
 @show ΔE = energy[1] - energy[end]
@@ -465,7 +466,7 @@ Plots.plot(
 
 And let's try to use a Runge-Kutta-Nyström solver to solve this. Note that Runge-Kutta-Nyström isn't symplectic.
 
-```@example physics
+```@example henon-heiles
 sol3 = ODE.solve(prob, ODERKN.DPRKN6());
 energy = map(x -> E(x[3], x[4], x[1], x[2]), sol3.u)
 @show ΔE = energy[1] - energy[end]


### PR DESCRIPTION
Supersedes #903 by @abhro, which is the same change plus the one import it needs to build.

## The problem with #903 as-is

Splitting the single shared `@example physics` block into per-topic groups gives each group its
own module, so a group no longer inherits imports from earlier blocks. The last henon-heiles
block calls

```julia
sol3 = ODE.solve(prob, ODERKN.DPRKN6());
```

but `OrdinaryDiffEqRKN` was imported only in the harmonic-oscillator block, which #903 makes
anonymous — and anonymous `@example` blocks each get their own module too. So `ODERKN` is
undefined in the henon-heiles module and `makedocs` fails. That is the `docs/make.jl:175`
failure on #903, a genuine build break rather than the deploy-token noise that fork PRs usually
hit.

## Fix

Import `OrdinaryDiffEqRKN as ODERKN` in the henon-heiles block that builds the
`SecondOrderODEProblem` the solver is applied to, next to the existing `ODESymp` import.

I checked the other groups for the same class of problem: `simple-pendulum`, `double-pendulum`
and both anonymous blocks define everything they use (`polar2cart`, `cb`, `poincare`,
`poincare_map`, `E`, `V`, `prob`), so `ODERKN` was the only escapee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R