### PR TITLE
Revert the classical_physics example-group split

### DIFF
--- a/docs/src/examples/classical_physics.md
+++ b/docs/src/examples/classical_physics.md
@@ -12,7 +12,7 @@ If you're getting some cold feet to jump in to DiffEq land, here are some handcr
 
 The Radioactive decay problem is the first order linear ODE problem of an exponential with a negative coefficient, which represents the half-life of the process in question. Should the coefficient be positive, this would represent a population growth equation. ``λ`` is known as the decay rate, and can be related to the half-life as ``λ = \ln(2)/t_{1/2}``.
 
-```@example
+```@example physics
 import OrdinaryDiffEq as ODE, Plots
 Plots.gr()
 
@@ -70,7 +70,7 @@ with ``c_1``, ``c_2`` constants determined by the initial conditions such that
 Instead of transforming this to a system of ODEs to solve with `ODEProblem`,
 we can use `SecondOrderODEProblem` as follows.
 
-```@example
+```@example physics
 # Simple Harmonic Oscillator Problem
 import OrdinaryDiffEq as ODE
 import OrdinaryDiffEqRKN as ODERKN # DPRKN6
@@ -135,7 +135,7 @@ of first order ODEs by employing the notation ``ω(t) = \dot{θ}``.
 \end{align*}
 ```
 
-```@example simple-pendulum
+```@example physics
 # Simple Pendulum Problem
 import OrdinaryDiffEq as ODE, Plots
 
@@ -168,7 +168,7 @@ Plots.plot(
 
 So now we know that behaviour of the position versus time. However, it will be useful to us to look at the phase space of the pendulum, i.e., and representation of all possible states of the system in question (the pendulum) by looking at its velocity and position. Phase space analysis is ubiquitous in the analysis of dynamical systems, and thus we will provide a few facilities for it.
 
-```@example simple-pendulum
+```@example physics
 p = Plots.plot(
     sol, vars = (1, 2), xlims = (-9, 9), title = "Phase Space Plot",
     xaxis = "Angular position", yaxis = "Angular velocity", leg = false
@@ -203,7 +203,7 @@ its motion are given by the following (taken from this [Stack Overflow question]
 \end{pmatrix}
 ```
 
-```@example double-pendulum
+```@example physics
 #Double Pendulum Problem
 import OrdinaryDiffEq as ODE, Plots
 
@@ -252,7 +252,7 @@ double_pendulum_problem = ODE.ODEProblem(double_pendulum, initial, tspan)
 sol = ODE.solve(double_pendulum_problem, ODE.Vern7(), abstol = 1.0e-10, dt = 0.05);
 ```
 
-```@example double-pendulum
+```@example physics
 #Obtain coordinates in Cartesian Geometry
 ts, ps = polar2cart(sol, l1 = L₁, l2 = L₂, dt = 0.01)
 Plots.plot(ps...)
@@ -267,7 +267,7 @@ This helps to understand the dynamics of interactions and is wonderfully pretty.
 
 The Poincaré section in this is given by the collection of ``(β,l_β)`` when ``α=0`` and ``\frac{dα}{dt}>0``.
 
-```@example double-pendulum
+```@example physics
 #Constants and setup
 import OrdinaryDiffEq as ODE
 initial2 = [0.01, 0.005, 0.01, 0.01]
@@ -310,7 +310,7 @@ function poincare_map(prob, u₀, p; callback = cb)
 end
 ```
 
-```@example double-pendulum
+```@example physics
 lβrange = -0.02:0.0025:0.02
 p = Plots.scatter(sol2, idxs = (3, 4), leg = false, markersize = 3, msw = 0)
 for lβ in lβrange
@@ -350,7 +350,7 @@ E = T+V = V(x,y) + \frac{1}{2} \left(\dot{x}^2+\dot{y}^2\right).
 
 The total energy should conserve as this system evolves.
 
-```@example henon-heiles
+```@example physics
 import OrdinaryDiffEq as ODE, Plots
 
 #Setup
@@ -377,7 +377,7 @@ prob = ODE.ODEProblem(Hénon_Heiles, initial, tspan)
 sol = ODE.solve(prob, ODE.Vern9(), abstol = 1.0e-16, reltol = 1.0e-16);
 ```
 
-```@example henon-heiles
+```@example physics
 # Plot the orbit
 Plots.plot(
     sol, idxs = (1, 2), title = "The orbit of the Hénon-Heiles system",
@@ -385,7 +385,7 @@ Plots.plot(
 )
 ```
 
-```@example henon-heiles
+```@example physics
 #Optional Sanity check - what do you think this returns and why?
 @show sol.retcode
 
@@ -397,7 +397,7 @@ Plots.plot(
 Plots.plot!(sol, idxs = (2, 4), leg = false)
 ```
 
-```@example henon-heiles
+```@example physics
 #We map the Total energies during the time intervals of the solution (sol.u here) to a new vector
 #pass it to the plotter a bit more conveniently
 energy = map(x -> E(x...), sol.u)
@@ -416,9 +416,8 @@ Plots.plot(
 
 To prevent energy drift, we can instead use a symplectic integrator. We can directly define and solve the `SecondOrderODEProblem`:
 
-```@example henon-heiles
+```@example physics
 import OrdinaryDiffEqSymplecticRK as ODESymp # KahanLi8
-import OrdinaryDiffEqRKN as ODERKN # DPRKN6
 function HH_acceleration!(dv, v, u, p, t)
     x, y = u
     dx, dy = dv
@@ -434,7 +433,7 @@ sol2 = ODE.solve(prob, ODESymp.KahanLi8(), dt = 1 / 10);
 
 Notice that we get the same results:
 
-```@example henon-heiles
+```@example physics
 # Plot the orbit
 Plots.plot(
     sol2, idxs = (3, 4), title = "The orbit of the Hénon-Heiles system",
@@ -442,7 +441,7 @@ Plots.plot(
 )
 ```
 
-```@example henon-heiles
+```@example physics
 Plots.plot(
     sol2, idxs = (3, 1), title = "Phase space for the Hénon-Heiles system",
     xaxis = "Position", yaxis = "Velocity"
@@ -452,7 +451,7 @@ Plots.plot!(sol2, idxs = (4, 2), leg = false)
 
 but now the energy change is essentially zero:
 
-```@example henon-heiles
+```@example physics
 energy = map(x -> E(x[3], x[4], x[1], x[2]), sol2.u)
 #We use @show here to easily spot erratic behaviour in our system by seeing if the loss in energy was too great.
 @show ΔE = energy[1] - energy[end]
@@ -466,7 +465,7 @@ Plots.plot(
 
 And let's try to use a Runge-Kutta-Nyström solver to solve this. Note that Runge-Kutta-Nyström isn't symplectic.
 
-```@example henon-heiles
+```@example physics
 sol3 = ODE.solve(prob, ODERKN.DPRKN6());
 energy = map(x -> E(x[3], x[4], x[1], x[2]), sol3.u)
 @show ΔE = energy[1] - energy[end]


### PR DESCRIPTION
Reverts #904. It broke the docs build on master.

Splitting the shared `@example physics` block into per-topic groups gives each group its own
module, so every name a group uses must be defined *within that group*. #904 fixed one escapee
(`ODERKN`) but not all of them: the `double-pendulum` group also uses `g`, which is defined in
an earlier block, so `makedocs` fails with

```
UndefVarError: `g` not defined in `Main.var"__atexample__named__double-pendulum"`
```

and the following block then cascades on `sol`.

Restoring the single `physics` group unbreaks the build. The split is still worth doing — it is
a real readability improvement — but it needs every cross-block name resolved first, which is
best verified by a full docs build before merging rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R